### PR TITLE
feat: Add dashboard tab for worktrees and repository overview

### DIFF
--- a/frontend/src/components/RepositoryPanel.tsx
+++ b/frontend/src/components/RepositoryPanel.tsx
@@ -8,9 +8,11 @@ interface RepositoryPanelProps {
   repositories: Repository[];
   instances: ClaudeInstance[];
   selectedWorktreeId: string | null;
+  selectedRepositoryId?: string | null;
   onAddRepository: (path: string) => void;
   onCreateWorktreeAndStartInstance: (repositoryId: string, branchName: string, agentType?: AgentType) => void;
   onSelectWorktree: (worktreeId: string) => Promise<void>;
+  onSelectRepository?: (repositoryId: string) => void;
   onDeleteWorktree: (worktreeId: string, force: boolean) => Promise<void>;
   onRefreshMainBranch: (repositoryId: string) => Promise<void>;
   isCollapsed: boolean;
@@ -22,9 +24,11 @@ export const RepositoryPanel: React.FC<RepositoryPanelProps> = ({
   repositories,
   instances,
   selectedWorktreeId,
+  selectedRepositoryId,
   onAddRepository,
   onCreateWorktreeAndStartInstance,
   onSelectWorktree,
+  onSelectRepository,
   onDeleteWorktree,
   onRefreshMainBranch,
   isCollapsed,
@@ -215,7 +219,18 @@ export const RepositoryPanel: React.FC<RepositoryPanelProps> = ({
                   <div key={repo.id} className="repository-item">
                     <div className="repository-header">
                       <div className="repository-info">
-                        <h4>{repo.name}</h4>
+                        <h4
+                          onClick={() => onSelectRepository?.(repo.id)}
+                          style={{
+                            cursor: 'pointer',
+                            color: selectedRepositoryId === repo.id ? '#58a6ff' : 'inherit',
+                            transition: 'color 0.2s'
+                          }}
+                          onMouseEnter={(e) => e.currentTarget.style.color = '#58a6ff'}
+                          onMouseLeave={(e) => e.currentTarget.style.color = selectedRepositoryId === repo.id ? '#58a6ff' : ''}
+                        >
+                          {repo.name}
+                        </h4>
                         <p>{repo.path}</p>
                         <div style={{ 
                           fontSize: '12px', 

--- a/frontend/src/components/__tests__/AgentPanel.spec.tsx
+++ b/frontend/src/components/__tests__/AgentPanel.spec.tsx
@@ -1,4 +1,4 @@
-import { render, screen } from '@testing-library/react';
+import { render, screen, fireEvent } from '@testing-library/react';
 import { vi } from 'vitest';
 import React from 'react';
 import { AgentPanel } from '../../components/AgentPanel';
@@ -45,5 +45,167 @@ describe('AgentPanel header', () => {
     // Verify header label and agent badge
     expect(screen.getByText('Agent Instance')).toBeTruthy();
     expect(screen.getByText('CODEX')).toBeTruthy();
+  });
+});
+
+describe('AgentPanel dashboard tab', () => {
+  const selectedWorktree = {
+    id: 'wt1',
+    path: '/tmp/repo1/wt1',
+    branch: 'feature/test',
+    repositoryId: 'repo1',
+    instances: [],
+    isMainWorktree: false,
+  } as any;
+
+  const selectedInstance = {
+    id: 'inst1',
+    worktreeId: 'wt1',
+    repositoryId: 'repo1',
+    agentType: 'claude',
+    status: 'running',
+    pid: 12345,
+    port: 3000,
+    createdAt: new Date().toISOString(),
+  } as any;
+
+  it('shows dashboard tab as first tab', () => {
+    render(
+      <AgentPanel
+        selectedWorktree={selectedWorktree}
+        selectedInstance={selectedInstance}
+        onCreateTerminalSession={async () => 's1'}
+        onCreateDirectoryTerminalSession={async () => 's2'}
+        onCloseTerminalSession={() => {}}
+        onRestartInstance={async () => {}}
+        onStopInstance={async () => {}}
+        onDeleteWorktree={async () => {}}
+        error={null}
+        isLeftPanelCollapsed={false}
+      />
+    );
+
+    // Verify Dashboard tab exists and is the first tab
+    const dashboardTab = screen.getByText('Dashboard');
+    expect(dashboardTab).toBeTruthy();
+
+    // Also verify other tabs exist
+    expect(screen.getByText(/Agent/)).toBeTruthy();
+    expect(screen.getByText(/Terminal/)).toBeTruthy();
+    expect(screen.getByText('Git')).toBeTruthy();
+    expect(screen.getByText('Notes')).toBeTruthy();
+  });
+
+  it('shows dashboard content by default', () => {
+    render(
+      <AgentPanel
+        selectedWorktree={selectedWorktree}
+        selectedInstance={selectedInstance}
+        onCreateTerminalSession={async () => 's1'}
+        onCreateDirectoryTerminalSession={async () => 's2'}
+        onCloseTerminalSession={() => {}}
+        onRestartInstance={async () => {}}
+        onStopInstance={async () => {}}
+        onDeleteWorktree={async () => {}}
+        error={null}
+        isLeftPanelCollapsed={false}
+      />
+    );
+
+    // Verify dashboard content is visible
+    expect(screen.getByText('Worktree Overview')).toBeTruthy();
+    expect(screen.getByText('Branch Information')).toBeTruthy();
+    expect(screen.getByText('Agent Status')).toBeTruthy();
+    expect(screen.getByText('Quick Actions')).toBeTruthy();
+  });
+
+  it('displays worktree information in dashboard', () => {
+    render(
+      <AgentPanel
+        selectedWorktree={selectedWorktree}
+        selectedInstance={selectedInstance}
+        onCreateTerminalSession={async () => 's1'}
+        onCreateDirectoryTerminalSession={async () => 's2'}
+        onCloseTerminalSession={() => {}}
+        onRestartInstance={async () => {}}
+        onStopInstance={async () => {}}
+        onDeleteWorktree={async () => {}}
+        error={null}
+        isLeftPanelCollapsed={false}
+      />
+    );
+
+    // Check worktree details are shown
+    expect(screen.getByText('feature/test')).toBeTruthy();
+    expect(screen.getByText('/tmp/repo1/wt1')).toBeTruthy();
+  });
+
+  it('displays agent status in dashboard', () => {
+    render(
+      <AgentPanel
+        selectedWorktree={selectedWorktree}
+        selectedInstance={selectedInstance}
+        onCreateTerminalSession={async () => 's1'}
+        onCreateDirectoryTerminalSession={async () => 's2'}
+        onCloseTerminalSession={() => {}}
+        onRestartInstance={async () => {}}
+        onStopInstance={async () => {}}
+        onDeleteWorktree={async () => {}}
+        error={null}
+        isLeftPanelCollapsed={false}
+      />
+    );
+
+    // Check agent details are shown
+    expect(screen.getByText('running')).toBeTruthy();
+    expect(screen.getByText('claude')).toBeTruthy();
+    expect(screen.getByText('12345')).toBeTruthy();
+    expect(screen.getByText('3000')).toBeTruthy();
+  });
+
+  it('shows no agent message when instance is null', () => {
+    render(
+      <AgentPanel
+        selectedWorktree={selectedWorktree}
+        selectedInstance={null}
+        onCreateTerminalSession={async () => 's1'}
+        onCreateDirectoryTerminalSession={async () => 's2'}
+        onCloseTerminalSession={() => {}}
+        onRestartInstance={async () => {}}
+        onStopInstance={async () => {}}
+        onDeleteWorktree={async () => {}}
+        error={null}
+        isLeftPanelCollapsed={false}
+      />
+    );
+
+    expect(screen.getByText('No agent instance running')).toBeTruthy();
+  });
+
+  it('can switch from dashboard to agent tab', () => {
+    render(
+      <AgentPanel
+        selectedWorktree={selectedWorktree}
+        selectedInstance={selectedInstance}
+        onCreateTerminalSession={async () => 's1'}
+        onCreateDirectoryTerminalSession={async () => 's2'}
+        onCloseTerminalSession={() => {}}
+        onRestartInstance={async () => {}}
+        onStopInstance={async () => {}}
+        onDeleteWorktree={async () => {}}
+        error={null}
+        isLeftPanelCollapsed={false}
+      />
+    );
+
+    // Dashboard content should be visible initially
+    expect(screen.getByText('Worktree Overview')).toBeTruthy();
+
+    // Click on Agent tab
+    const agentTab = screen.getByText(/Agent/);
+    fireEvent.click(agentTab);
+
+    // Dashboard content should no longer be visible
+    expect(screen.queryByText('Worktree Overview')).toBeFalsy();
   });
 });

--- a/frontend/src/components/__tests__/App.test.tsx
+++ b/frontend/src/components/__tests__/App.test.tsx
@@ -1,0 +1,164 @@
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { vi } from 'vitest';
+import React from 'react';
+import { BrowserRouter } from 'react-router-dom';
+import App from '../../App';
+import * as api from '../../api';
+
+// Mock the API
+vi.mock('../../api', () => ({
+  api: {
+    getRepositories: vi.fn(),
+    getInstances: vi.fn(),
+    getAgents: vi.fn(),
+    addRepository: vi.fn(),
+    createWorktree: vi.fn(),
+    startInstance: vi.fn(),
+    removeWorktree: vi.fn(),
+    refreshMainBranch: vi.fn(),
+    createTerminalSession: vi.fn(),
+    createDirectoryTerminalSession: vi.fn(),
+    closeTerminalSession: vi.fn(),
+    restartInstance: vi.fn(),
+    stopInstance: vi.fn(),
+  },
+}));
+
+// Mock components that have complex dependencies
+vi.mock('../../components/Terminal', () => ({
+  TerminalComponent: () => <div data-testid="terminal-mock" />,
+}));
+
+vi.mock('../../components/DirectoryBrowser', () => ({
+  DirectoryBrowser: () => <div data-testid="directory-browser-mock" />,
+}));
+
+vi.mock('../../components/Dashboard', () => ({
+  Dashboard: ({ repositories }: any) => (
+    <div data-testid="dashboard-component">
+      Dashboard for {repositories[0]?.name}
+    </div>
+  ),
+}));
+
+vi.mock('../../components/AuthButton', () => ({
+  AuthButton: () => <div data-testid="auth-button" />,
+}));
+
+vi.mock('../../components/SettingsMenu', () => ({
+  SettingsMenu: () => <div data-testid="settings-menu" />,
+}));
+
+vi.mock('../../components/WebSocketDebugPanel', () => ({
+  WebSocketDebugPanel: () => <div data-testid="websocket-debug" />,
+}));
+
+vi.mock('../../contexts/CheatCodeContext', () => ({
+  useCheatCode: () => ({ isDatabaseUnlocked: false }),
+  CheatCodeProvider: ({ children }: any) => children,
+}));
+
+describe('App - Repository and Worktree Selection', () => {
+  const mockRepositories = [
+    {
+      id: 'repo1',
+      name: 'Test Repo',
+      path: '/tmp/test-repo',
+      branch: 'main',
+      mainBranch: 'main',
+      worktrees: [
+        {
+          id: 'wt1',
+          path: '/tmp/test-repo/wt1',
+          branch: 'feature/test',
+          repositoryId: 'repo1',
+          instances: [],
+          isMainWorktree: false,
+        },
+      ],
+    },
+  ];
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    (api.api.getRepositories as any).mockResolvedValue(mockRepositories);
+    (api.api.getInstances as any).mockResolvedValue([]);
+    (api.api.getAgents as any).mockResolvedValue([
+      { type: 'claude', name: 'Claude Code', isAvailable: true, isAuthenticated: true },
+    ]);
+  });
+
+  it('shows Dashboard component when repository is selected', async () => {
+    render(
+      <BrowserRouter>
+        <App />
+      </BrowserRouter>
+    );
+
+    // Wait for data to load
+    await waitFor(() => {
+      expect(screen.getByText('Test Repo')).toBeTruthy();
+    });
+
+    // Click on repository name to select it
+    const repoName = screen.getByText('Test Repo');
+    fireEvent.click(repoName);
+
+    // Should show Dashboard component
+    await waitFor(() => {
+      expect(screen.getByTestId('dashboard-component')).toBeTruthy();
+      expect(screen.getByText('Dashboard for Test Repo')).toBeTruthy();
+    });
+  });
+
+  it('shows AgentPanel when worktree is selected', async () => {
+    render(
+      <BrowserRouter>
+        <App />
+      </BrowserRouter>
+    );
+
+    // Wait for data to load
+    await waitFor(() => {
+      expect(screen.getByText('Test Repo')).toBeTruthy();
+    });
+
+    // Click on worktree to select it
+    const worktreeBranch = screen.getByText('feature/test');
+    fireEvent.click(worktreeBranch);
+
+    // Should show AgentPanel (not Dashboard)
+    await waitFor(() => {
+      expect(screen.queryByTestId('dashboard-component')).toBeFalsy();
+      // AgentPanel shows the instance header
+      expect(screen.getByText('Agent Instance')).toBeTruthy();
+    });
+  });
+
+  it('clears repository selection when worktree is selected', async () => {
+    render(
+      <BrowserRouter>
+        <App />
+      </BrowserRouter>
+    );
+
+    await waitFor(() => {
+      expect(screen.getByText('Test Repo')).toBeTruthy();
+    });
+
+    // First select repository
+    fireEvent.click(screen.getByText('Test Repo'));
+
+    await waitFor(() => {
+      expect(screen.getByTestId('dashboard-component')).toBeTruthy();
+    });
+
+    // Then select worktree
+    fireEvent.click(screen.getByText('feature/test'));
+
+    // Dashboard should disappear
+    await waitFor(() => {
+      expect(screen.queryByTestId('dashboard-component')).toBeFalsy();
+    });
+  });
+});

--- a/frontend/src/components/__tests__/RepositoryPanel.spec.tsx
+++ b/frontend/src/components/__tests__/RepositoryPanel.spec.tsx
@@ -1,4 +1,5 @@
 import { render, screen, fireEvent } from '@testing-library/react';
+import { vi } from 'vitest';
 import React from 'react';
 import { RepositoryPanel } from '../../components/RepositoryPanel';
 
@@ -59,6 +60,103 @@ describe('RepositoryPanel agent selection', () => {
     expect(args[0]).toBe('repo1');
     expect(args[1]).toBe('feat-test');
     expect(args[2]).toBe('codex');
+  });
+});
+
+describe('RepositoryPanel repository selection', () => {
+  const repositories = [
+    {
+      id: 'repo1',
+      name: 'Test Repository',
+      path: '/tmp/test-repo',
+      branch: 'main',
+      mainBranch: 'main',
+      worktrees: [
+        { id: 'wt1', path: '/tmp/test-repo/wt1', branch: 'feature/test', repositoryId: 'repo1', instances: [], isMainWorktree: false },
+      ],
+    },
+  ];
+
+  const instances: any[] = [];
+  const agents = [
+    { type: 'claude', name: 'Claude Code', command: 'claude', isAvailable: true, isAuthenticated: true },
+  ] as any[];
+
+  it('calls onSelectRepository when repository name is clicked', () => {
+    const onSelectRepository = vi.fn();
+    render(
+      <RepositoryPanel
+        repositories={repositories as any}
+        instances={instances as any}
+        selectedWorktreeId={null}
+        selectedRepositoryId={null}
+        onAddRepository={vi.fn()}
+        onCreateWorktreeAndStartInstance={vi.fn()}
+        onSelectWorktree={vi.fn() as any}
+        onSelectRepository={onSelectRepository}
+        onDeleteWorktree={vi.fn() as any}
+        onRefreshMainBranch={vi.fn() as any}
+        isCollapsed={false}
+        onToggleCollapse={() => {}}
+        agents={agents as any}
+      />
+    );
+
+    // Click on repository name
+    const repoName = screen.getByText('Test Repository');
+    fireEvent.click(repoName);
+
+    expect(onSelectRepository).toHaveBeenCalledWith('repo1');
+  });
+
+  it('highlights selected repository', () => {
+    render(
+      <RepositoryPanel
+        repositories={repositories as any}
+        instances={instances as any}
+        selectedWorktreeId={null}
+        selectedRepositoryId="repo1"
+        onAddRepository={vi.fn()}
+        onCreateWorktreeAndStartInstance={vi.fn()}
+        onSelectWorktree={vi.fn() as any}
+        onSelectRepository={vi.fn()}
+        onDeleteWorktree={vi.fn() as any}
+        onRefreshMainBranch={vi.fn() as any}
+        isCollapsed={false}
+        onToggleCollapse={() => {}}
+        agents={agents as any}
+      />
+    );
+
+    // Get the repository name element
+    const repoName = screen.getByText('Test Repository');
+
+    // Check that it has the highlighted color style
+    expect(repoName.style.color).toBe('rgb(88, 166, 255)'); // #58a6ff
+  });
+
+  it('does not call onSelectRepository if handler is not provided', () => {
+    // Should not throw error when onSelectRepository is undefined
+    render(
+      <RepositoryPanel
+        repositories={repositories as any}
+        instances={instances as any}
+        selectedWorktreeId={null}
+        onAddRepository={vi.fn()}
+        onCreateWorktreeAndStartInstance={vi.fn()}
+        onSelectWorktree={vi.fn() as any}
+        onDeleteWorktree={vi.fn() as any}
+        onRefreshMainBranch={vi.fn() as any}
+        isCollapsed={false}
+        onToggleCollapse={() => {}}
+        agents={agents as any}
+      />
+    );
+
+    const repoName = screen.getByText('Test Repository');
+
+    // Should not throw error
+    expect(() => fireEvent.click(repoName)).not.toThrow();
   });
 });
 


### PR DESCRIPTION
## Summary

This PR adds a dashboard tab for worktrees and enables repository overview functionality, improving the user experience when navigating between repositories and worktrees.

## Changes

### Dashboard Tab for Worktrees
- Added **Dashboard** as the first tab in worktree view (order: Dashboard → Agent → Terminal → Git → Notes)
- Dashboard displays:
  - Branch information (branch name, path)
  - Agent status (status, type, PID, port)
  - Quick action buttons to open Agent Terminal, Directory Terminal, Git, and Notes tabs
- Clicking a worktree now opens the Dashboard tab by default
- **No automatic agent instance creation** - users must explicitly open Agent tab or use quick action buttons

### Repository Overview
- Repository names in the left panel are now clickable
- Clicking a repository name shows the repository-level Dashboard component
- Displays all worktrees for that repository with their status, agents, and git info
- Repository names highlight in blue when selected

### Architecture Improvements
- Removed separate `/dashboard` route in favor of inline dashboard views
- Updated session reconnection logic to not force tab switches
- Dashboard and worktree views are mutually exclusive

### Testing
- Added comprehensive test coverage:
  - App-level tests for repository/worktree selection
  - AgentPanel tests for dashboard tab functionality
  - RepositoryPanel tests for repository selection
- All tests follow existing Vitest + React Testing Library patterns

## Test Plan

- [x] Click on repository name - should show repository dashboard
- [x] Click on worktree - should show worktree view with Dashboard tab active
- [x] Verify no auto-start of agent instances when selecting worktree
- [x] Use quick action buttons to navigate to other tabs
- [x] Switch between tabs manually
- [x] Verify repository highlighting when selected
- [x] Run test suite: `npm test`

🤖 Generated with [Claude Code](https://claude.com/claude-code)