### PR TITLE
fix(bob): monitor silent dead-loop + reap zombie sessions

### DIFF
--- a/apps/bob/worker/index.ts
+++ b/apps/bob/worker/index.ts
@@ -137,6 +137,37 @@ export default Sentry.withSentry(
         }
         // 1. Dispatch backlog work.
         if (autoDrainOn) {
+          // 1a. Reap zombie sessions FIRST so freed slots are usable this tick.
+          // A session whose runner died lingers in an active status forever and
+          // permanently consumes an autoDrain slot; enough of them starve the
+          // whole pipeline ("no free slots"). Gated so it can be disabled with a
+          // var change, no redeploy. Best-effort — a reaper failure must not
+          // block dispatch, so it's caught and logged, never thrown.
+          if (String(runtimeEnv.BOB_SESSION_REAP_ENABLED ?? "true") !== "false") {
+            try {
+              const { reapStuckSessions } = await import(
+                "@bob/api/handlers/reapStuckSessions"
+              );
+              const reap = await reapStuckSessions({
+                leaseGraceMs: runtimeEnv.BOB_SESSION_REAP_LEASE_GRACE_MS
+                  ? Number(runtimeEnv.BOB_SESSION_REAP_LEASE_GRACE_MS)
+                  : undefined,
+                hardTimeoutMs: runtimeEnv.BOB_SESSION_REAP_HARD_TIMEOUT_MS
+                  ? Number(runtimeEnv.BOB_SESSION_REAP_HARD_TIMEOUT_MS)
+                  : undefined,
+              });
+              if (reap.reaped > 0) {
+                console.log(
+                  `[session-reap] reaped=${reap.reaped} sessions=${reap.sessions
+                    .map((s) => `${s.id.slice(0, 8)}:${s.status}`)
+                    .join(",")}`,
+                );
+              }
+            } catch (err) {
+              console.error("[session-reap] failed:", err);
+            }
+          }
+
           const { autoDrainBacklog } = await import(
             "@bob/api/handlers/autoDrain"
           );
@@ -213,10 +244,48 @@ export default Sentry.withSentry(
           });
           console.log(
             `[auto-merge] scanned=${r.scanned} reviewed=${r.reviewed} repaired=${r.repaired} merged=${r.merged} skipped=${r.skipped}` +
+              (r.authFailures ? ` authFailures=${r.authFailures}` : "") +
               (r.items.length
                 ? ` items=${r.items.map((i) => `${i.pr}:${i.action}${i.reason ? `(${i.reason})` : ""}`).join(", ")}`
                 : ""),
           );
+          // Silent-dead-loop guard: a revoked/expired shared Forgejo token makes
+          // EVERY PR 401 and get counted as an ordinary "skip", so the counters
+          // look healthy (scanned=N skipped=N) while the review→repair→merge loop
+          // is fully dead — exactly the 2026-07-29 outage that went unnoticed for
+          // ~23h. Escalate loudly when auth failures dominate a run that produced
+          // no forward progress. Threshold (not >0) so a single expired per-user
+          // OAuth connection doesn't page.
+          const authDominates =
+            r.authFailures > 0 &&
+            r.reviewed + r.repaired + r.merged === 0 &&
+            r.authFailures >= Math.max(3, Math.floor(r.scanned / 2));
+          if (authDominates) {
+            const { buildFailurePayload, getFailureSentryTags } = await import(
+              "@bob/observability/failures"
+            );
+            const failure = {
+              surface: "job" as const,
+              operation: "auto_merge_review",
+              error: new Error(
+                `auto-merge git-host auth failing on ${r.authFailures}/${r.scanned} PRs with 0 forward progress — shared Forgejo token likely revoked/expired`,
+              ),
+              alertId: "auto-merge-auth-failure",
+              tenant: runtimeEnv.BOB_TENANT_ID
+                ? { tenantId: String(runtimeEnv.BOB_TENANT_ID) }
+                : undefined,
+            };
+            console.error(
+              "[auto-merge] AUTH FAILURE — dispatch loop is dead",
+              buildFailurePayload(failure),
+            );
+            Sentry.withScope((scope) => {
+              scope.setLevel("error");
+              scope.setTags(getFailureSentryTags(failure));
+              scope.setContext("failure", buildFailurePayload(failure));
+              Sentry.captureException(failure.error);
+            });
+          }
         }
       });
       ctx.waitUntil(work);

--- a/packages/bob/src/api/src/handlers/__tests__/autoMergeReview.authError.test.ts
+++ b/packages/bob/src/api/src/handlers/__tests__/autoMergeReview.authError.test.ts
@@ -1,0 +1,42 @@
+import { describe, it, expect } from "vitest";
+
+import { isAuthError } from "../autoMergeReview";
+
+// Regression guard for the 2026-07-29 silent dead-loop: a revoked shared Forgejo
+// token made every PR 401, but each 401 was counted as an ordinary "skip", so
+// the [auto-merge] counters looked healthy while the pipeline was fully dead for
+// ~23h. isAuthError is what now separates a token-wide auth failure (escalated)
+// from per-PR noise (ignored) — a false negative here reintroduces the outage.
+describe("isAuthError", () => {
+  it("matches the exact Forgejo revoked-token error from the incident", () => {
+    const err = new Error(
+      'Gitea API error (401): {"message":"access token does not exist [sha: fc24d9ef44fab0500150e782a7d8c121c689f6f8]"}',
+    );
+    expect(isAuthError(err)).toBe(true);
+  });
+
+  it("matches generic 401/403 and credential-shaped messages", () => {
+    expect(isAuthError(new Error("Request failed with status 403"))).toBe(true);
+    expect(
+      isAuthError(new Error("remote: Credentials are incorrect or have expired.")),
+    ).toBe(true);
+    expect(isAuthError(new Error("401 Unauthorized"))).toBe(true);
+    expect(isAuthError("HTTP (403) forbidden")).toBe(true);
+  });
+
+  it("is case-insensitive", () => {
+    expect(isAuthError(new Error("ACCESS TOKEN DOES NOT EXIST"))).toBe(true);
+    expect(isAuthError(new Error("UNAUTHORIZED"))).toBe(true);
+  });
+
+  it("does NOT match ordinary per-PR failures (no false page)", () => {
+    expect(isAuthError(new Error("merge conflict in src/index.ts"))).toBe(false);
+    expect(isAuthError(new Error("Gitea API error (404): not found"))).toBe(false);
+    expect(isAuthError(new Error("Gitea API error (500): internal error"))).toBe(
+      false,
+    );
+    expect(isAuthError(new Error("CI status pending"))).toBe(false);
+    expect(isAuthError(new Error("ECONNRESET"))).toBe(false);
+    expect(isAuthError(undefined)).toBe(false);
+  });
+});

--- a/packages/bob/src/api/src/handlers/autoMergeReview.ts
+++ b/packages/bob/src/api/src/handlers/autoMergeReview.ts
@@ -127,11 +127,41 @@ export interface AutoMergeResult {
   repaired: number;
   merged: number;
   skipped: number;
+  /**
+   * How many PRs failed with a git-host AUTH error (401/403 / revoked token)
+   * this run. These also land in `skipped`, but are counted separately because
+   * a token-wide auth failure is a silent-dead-loop signal, not per-PR noise:
+   * when it dominates, the whole review→repair→merge pipeline is down even
+   * though the cron keeps firing and the counters look "healthy" (all skipped).
+   * The worker escalates on this — see the `auto-merge-auth-failure` alert.
+   */
+  authFailures: number;
   items: {
     pr: string;
     action: "merged" | "reviewed" | "repaired" | "skipped";
     reason?: string;
   }[];
+}
+
+/**
+ * Does this error look like a git-host authentication/authorization failure
+ * (revoked/expired token, bad credentials) rather than a per-PR problem? Used
+ * to distinguish a fleet-wide dead token from ordinary skips. Matches the shape
+ * Forgejo/Gitea returns for a dead token: `Gitea API error (401): {"message":
+ * "access token does not exist [...]"}`, plus generic 401/403/credential text.
+ */
+export function isAuthError(err: unknown): boolean {
+  const msg = (err instanceof Error ? err.message : String(err)).toLowerCase();
+  return (
+    msg.includes("(401)") ||
+    msg.includes("(403)") ||
+    msg.includes("status 401") ||
+    msg.includes("status 403") ||
+    msg.includes("access token does not exist") ||
+    msg.includes("unauthorized") ||
+    msg.includes("credentials are incorrect") ||
+    msg.includes("token does not exist")
+  );
 }
 
 /** Is a review session already in flight for this PR? (suppresses re-dispatch) */
@@ -194,6 +224,7 @@ export async function autoReviewAndMerge(
     repaired: 0,
     merged: 0,
     skipped: 0,
+    authFailures: 0,
     items: [],
   };
 
@@ -546,6 +577,7 @@ export async function autoReviewAndMerge(
       result.items.push({ pr: label, action: "merged" });
     } catch (err) {
       result.skipped++;
+      if (isAuthError(err)) result.authFailures++;
       result.items.push({
         pr: label,
         action: "skipped",

--- a/packages/bob/src/api/src/handlers/reapStuckSessions.ts
+++ b/packages/bob/src/api/src/handlers/reapStuckSessions.ts
@@ -1,0 +1,119 @@
+// Zombie-session reaper.
+//
+// autoDrain counts a session as "holding a runner slot" while its status is in
+// ACTIVE_SESSION_STATUSES (pending/provisioning/starting/running/blocked/
+// stopping/host_unknown). The ws-gateway's lease sweep moves a session whose
+// heartbeat lapsed to `host_unknown` — but NOTHING then terminates it, so a
+// session whose runner died sits in an active status forever and permanently
+// consumes a concurrency slot. Enough of them (`running=17-20, no free slots`)
+// starves autoDrain and the whole autonomous pipeline stalls.
+//
+// This reaper marks provably-dead sessions terminal so their slot frees. It is
+// deliberately conservative — it only touches sessions that are BOTH in an
+// active status AND past a generous timeout, so a live, recently-heartbeating
+// session is never killed:
+//   - lease-expired: `leaseExpiresAt` is in the past by more than `leaseGraceMs`
+//     (a live runner renews its lease every heartbeat, so an old expiry means
+//     the runner is gone); OR
+//   - never-leased + inactive: no lease was ever claimed and there has been no
+//     activity for longer than `hardTimeoutMs` (covers sessions wedged in
+//     pending/provisioning because dispatch died before a gateway claimed them).
+//
+// `blocked` is intentionally NOT reaped here: it means the run is paused on a
+// human decision, governed by `awaitingInputExpiresAt` (see awaitingInputExpiry
+// service), not a runner timeout — killing it on a clock would discard a
+// legitimately-waiting session.
+
+import { and, inArray, or, sql } from "@bob/db";
+import { db } from "@bob/db/client";
+import { chatConversations } from "@bob/db/schema";
+
+// Active statuses that hold an autoDrain slot, EXCEPT `blocked` (see header).
+const REAPABLE_ACTIVE_STATUSES = [
+  "pending",
+  "provisioning",
+  "starting",
+  "running",
+  "stopping",
+  "host_unknown",
+];
+
+export interface ReapStuckSessionsOptions {
+  /**
+   * How long a lease must have been expired before the session is considered
+   * dead. A live runner renews its lease every heartbeat (default grace 60s),
+   * so 30 min of expiry is unambiguous. Default 30 min.
+   */
+  leaseGraceMs?: number;
+  /**
+   * For sessions that never had a lease claimed, how long with no activity
+   * (lastActivityAt / updatedAt / createdAt) before they're reaped. Longer than
+   * the lease grace because there's no heartbeat to lean on. Default 2 h.
+   */
+  hardTimeoutMs?: number;
+  /** Don't write; just report what would be reaped. */
+  dryRun?: boolean;
+}
+
+export interface ReapStuckSessionsResult {
+  reaped: number;
+  sessions: { id: string; status: string; agentType: string | null }[];
+  dryRun: boolean;
+}
+
+export async function reapStuckSessions(
+  opts: ReapStuckSessionsOptions = {},
+): Promise<ReapStuckSessionsResult> {
+  const leaseGraceMs = opts.leaseGraceMs ?? 30 * 60 * 1000;
+  const hardTimeoutMs = opts.hardTimeoutMs ?? 2 * 60 * 60 * 1000;
+  const leaseGraceSecs = Math.floor(leaseGraceMs / 1000);
+  const hardTimeoutSecs = Math.floor(hardTimeoutMs / 1000);
+
+  // A session is dead if it's in an active-but-reapable status AND either its
+  // lease expired long ago, or it was never leased and has gone quiet.
+  const deadPredicate = and(
+    inArray(chatConversations.status, REAPABLE_ACTIVE_STATUSES),
+    or(
+      sql`${chatConversations.leaseExpiresAt} is not null
+        and ${chatConversations.leaseExpiresAt} < now() - make_interval(secs => ${leaseGraceSecs})`,
+      sql`${chatConversations.leaseExpiresAt} is null
+        and coalesce(${chatConversations.lastActivityAt}, ${chatConversations.updatedAt}, ${chatConversations.createdAt}::timestamptz)
+            < now() - make_interval(secs => ${hardTimeoutSecs})`,
+    ),
+  );
+
+  if (opts.dryRun) {
+    const rows = await db
+      .select({
+        id: chatConversations.id,
+        status: chatConversations.status,
+        agentType: chatConversations.agentType,
+      })
+      .from(chatConversations)
+      .where(deadPredicate);
+    return { reaped: rows.length, sessions: rows, dryRun: true };
+  }
+
+  const reaped = await db
+    .update(chatConversations)
+    .set({
+      status: "failed",
+      claimedByGatewayId: null,
+      leaseExpiresAt: null,
+      lastError: {
+        code: "reaped_stuck_session",
+        message:
+          "Reaped by the stuck-session sweep: active status with an expired lease / no activity past the timeout (runner presumed dead).",
+        timestamp: new Date().toISOString(),
+      },
+      updatedAt: new Date().toISOString(),
+    })
+    .where(deadPredicate)
+    .returning({
+      id: chatConversations.id,
+      status: chatConversations.status,
+      agentType: chatConversations.agentType,
+    });
+
+  return { reaped: reaped.length, sessions: reaped, dryRun: false };
+}

--- a/packages/bob/src/api/src/handlers/workItems.ts
+++ b/packages/bob/src/api/src/handlers/workItems.ts
@@ -1124,7 +1124,9 @@ export async function workItemsDispatch(
       systemPrompt: persona.systemPrompt ?? undefined,
       allowedTools: persona.allowedTools ?? undefined,
       autonomyLevel: persona.autonomyLevel ?? undefined,
-      metadata: persona.metadata ?? undefined,
+      // `metadata` is a non-null jsonb column (defaults to {}), so `?? undefined`
+      // is a no-op the `no-unnecessary-condition` lint rule (correctly) rejects.
+      metadata: persona.metadata,
     };
   }
 

--- a/packages/bob/src/observability/src/alerts.ts
+++ b/packages/bob/src/observability/src/alerts.ts
@@ -94,6 +94,19 @@ export const OBSERVABILITY_ALERTS: readonly ObservabilityAlertDefinition[] = [
     runbook:
       "Review worker scheduled handler logs, BOB_AUTO_DRAIN_ENABLED, and database/Hyperdrive bindings.",
   },
+  {
+    id: "auto-merge-auth-failure",
+    name: "Auto-merge git-host auth failure (silent dead loop)",
+    service: "bob-worker",
+    surface: "job",
+    severity: "high",
+    description:
+      "The auto-merge reaper is failing git-host auth (401/403) on most or all scanned PRs — the review→repair→merge loop is effectively dead while the cron keeps firing. Distinguishes a revoked/expired shared Forgejo token from ordinary per-PR skips, which otherwise look identical in the [auto-merge] counters.",
+    sentryTag: "surface:job",
+    posthogEvent: "critical_job_failure",
+    runbook:
+      "The BOB_FORGEJO_TOKEN (and/or BOB_REVIEW_FORGEJO_TOKEN) worker secret is likely revoked/expired. Verify against git.forgegraf.com, rotate via `wrangler secret put`, and update the hetzner-bob runner git auth. See ForgeGraph docs/ops/2026-07-29-forgejo-token-revocation-bob-dispatch-outage.md.",
+  },
 ] as const;
 
 export function getAlertsForSurface(


### PR DESCRIPTION
Two hardening follow-ups from the **2026-07-29 Forgejo-token outage**, where a revoked token silently dead-locked the review→repair→merge pipeline for ~23h while the cron kept firing and the `[auto-merge]` counters looked healthy.

## 1. Silent dead-loop monitoring
A revoked/expired shared Forgejo token makes **every** PR 401, but each 401 was counted as an ordinary `skipped` — so `scanned=N skipped=N` looked fine while the loop was fully dead.

- `autoReviewAndMerge` now classifies auth errors (`isAuthError`) and returns `authFailures` separately.
- The worker escalates (`console.error` + Sentry via the new `auto-merge-auth-failure` alert) **only when auth failures dominate a run with zero forward progress** — thresholded so a single expired per-user OAuth connection doesn't page.

## 2. Zombie-session reaper
The gateway lease sweep parks a dead-runner session in `host_unknown`, but nothing terminated it — so it held an autoDrain slot forever (`running=17-20`, "no free slots" starved dispatch).

- New `reapStuckSessions` handler marks provably-dead sessions `failed` (expired lease past a grace window, or never-leased + inactive past a hard timeout), freeing the slot.
- Runs at the **top** of the auto-drain cron so freed slots are usable the same tick.
- Conservative: never touches a live/recently-heartbeating session; leaves `blocked` (human-decision pause) alone.

Both gated by env vars (`BOB_SESSION_REAP_ENABLED`, thresholds) so they're tunable/disable-able without a redeploy.

## Verification
- Typecheck clean: `@bob/api` + worker (exit 0)
- `isAuthError` regression test — 4/4 pass (incl. the exact Forgejo revoked-token string from the incident + false-positive guards for 404/500/conflict)
- Reaper: verified by typecheck + conservative predicate; no mock unit test (the harness needs a live emulate Postgres, and a mock test would only assert the query-builder was called, not the SQL semantics)

Context: ForgeGraph `docs/ops/2026-07-29-forgejo-token-revocation-bob-dispatch-outage.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)