### PR TITLE
fix(bob-api): carry OODA correlation on the dispatch nudge path

### DIFF
--- a/packages/bob/src/api/src/handlers/publicApi.ts
+++ b/packages/bob/src/api/src/handlers/publicApi.ts
@@ -555,6 +555,13 @@ export async function publicApiDispatchExecution(
           sessionType: "execution",
           description: input.description ?? undefined,
           identifier,
+          // Carry the OODA correlation on the nudge path too. The gateway's
+          // nudgeSession() forwards `personaConfig` verbatim from this payload
+          // (relay.ts) and marks the session delivered, which dedupes the
+          // DB-reading deliverPendingSessionsToDaemon path. Without this, a
+          // nudge-delivered session reaches the runner with no
+          // personaConfig.metadata.ooda, so the M2 read-back silently no-ops.
+          personaConfig: input.ooda ? { metadata: { ooda: input.ooda } } : undefined,
         }),
       });
     } catch {


### PR DESCRIPTION
Adds `personaConfig:{metadata:{ooda}}` to the /internal/nudge payload so the OODA→Bob M2 read-back correlation survives the gateway's nudgeSession() delivery path (which forwards the nudge body verbatim and dedupes the DB-reading path).

**Verified live in production:** after deploying this fix, a re-dispatch logged `[bob-gw] OODA outcome reported` and committed a note to the OODA thread (`Promote: Bob run failed…`) — the round-trip that silently no-oped before the fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)