### PR TITLE
feat(ooda-edge): Dispatch to Bob action on the production thread UI

### DIFF
--- a/apps/ooda-edge/src/components/threads/bob-dispatch-bar.tsx
+++ b/apps/ooda-edge/src/components/threads/bob-dispatch-bar.tsx
@@ -1,0 +1,123 @@
+"use client";
+
+import { useState } from "react";
+
+import { useTRPC } from "~/trpc/react";
+import { useMutation } from "@tanstack/react-query";
+
+// Phase 5 M1 (OODA side, in-product): dispatch an executable Bob run from a
+// thread. Calls trpc.bob.dispatch, which POSTs to Bob's public /api/v1/dispatch
+// with this thread's slug/id as the correlation. When the run finishes, Bob's
+// runner writes the outcome back into this thread as a note (M2 read-back), so
+// the round-trip closes without any polling here.
+//
+// Dark until wired: if Bob dispatch env isn't configured the mutation returns
+// PRECONDITION_FAILED, and if Bob's endpoint is gated off it returns FORBIDDEN —
+// both surfaced inline so the failure is legible rather than silent.
+
+const AGENT_OPTIONS = ["auto", "claude", "grok", "codex", "cursor"] as const;
+
+export function BobDispatchBar({
+  threadSlug,
+  threadId,
+  onClose,
+}: {
+  threadSlug: string;
+  threadId: string;
+  onClose: () => void;
+}) {
+  const [title, setTitle] = useState("");
+  const [description, setDescription] = useState("");
+  const [agent, setAgent] = useState<(typeof AGENT_OPTIONS)[number]>("auto");
+
+  const trpc = useTRPC();
+  const dispatchMutation = useMutation(trpc.bob.dispatch.mutationOptions());
+
+  const submit = () => {
+    const trimmed = title.trim();
+    if (!trimmed) return;
+    dispatchMutation.mutate({
+      threadSlug,
+      threadId,
+      title: trimmed,
+      description: description.trim() || undefined,
+      agentType: agent === "auto" ? undefined : agent,
+    });
+  };
+
+  return (
+    <div className="flex flex-wrap items-center gap-x-3 gap-y-2 border-b border-[#D4A04A]/40 bg-[#2E2A1A] px-4 py-2">
+      <span className="shrink-0 font-mono text-xs text-[#D4A04A]">
+        Dispatch to Bob:
+      </span>
+      <input
+        type="text"
+        value={title}
+        onChange={(e) => setTitle(e.target.value)}
+        onKeyDown={(e) => {
+          if (e.key === "Enter" && !dispatchMutation.isPending) submit();
+        }}
+        placeholder="What should Bob build?"
+        aria-label="Bob run title"
+        className="min-w-0 flex-1 basis-56 rounded-[3px] border border-[#D4A04A]/30 bg-[#1A1A1E] px-2 py-1 font-mono text-xs text-[#E8E4DF] placeholder-[#5A5855] outline-none focus:border-[#D4A04A]"
+      />
+      <input
+        type="text"
+        value={description}
+        onChange={(e) => setDescription(e.target.value)}
+        placeholder="Details (optional)"
+        aria-label="Bob run description"
+        className="min-w-0 flex-1 basis-40 rounded-[3px] border border-[#D4A04A]/30 bg-[#1A1A1E] px-2 py-1 font-mono text-xs text-[#E8E4DF] placeholder-[#5A5855] outline-none focus:border-[#D4A04A]"
+      />
+      <select
+        value={agent}
+        onChange={(e) =>
+          setAgent(e.target.value as (typeof AGENT_OPTIONS)[number])
+        }
+        aria-label="Agent"
+        className="shrink-0 rounded-[3px] border border-[#D4A04A]/30 bg-[#1A1A1E] px-2 py-1 font-mono text-xs text-[#E8E4DF] outline-none"
+      >
+        {AGENT_OPTIONS.map((a) => (
+          <option key={a} value={a}>
+            {a}
+          </option>
+        ))}
+      </select>
+      <button
+        onClick={submit}
+        disabled={!title.trim() || dispatchMutation.isPending}
+        className="shrink-0 rounded-[3px] bg-[#D4A04A] px-3 py-1 font-mono text-xs font-medium text-[#111113] transition-opacity hover:opacity-90 disabled:opacity-50"
+      >
+        {dispatchMutation.isPending ? "Dispatching..." : "Dispatch"}
+      </button>
+      {/* Result / error line: aria-live so the outcome is announced. */}
+      <span
+        role="status"
+        aria-live="polite"
+        className="basis-full font-mono text-xs"
+      >
+        {dispatchMutation.isSuccess ? (
+          <span className="text-[#6BbF59]">
+            Dispatched {dispatchMutation.data.identifier} —{" "}
+            {dispatchMutation.data.status}. Bob will post the outcome back to
+            this thread.
+          </span>
+        ) : dispatchMutation.isError ? (
+          <span className="text-[#E06B6B]">
+            {dispatchMutation.error.message}
+          </span>
+        ) : (
+          <span className="text-[#5A5855]">
+            Runs in Bob; the result returns here as a thread note.
+          </span>
+        )}
+      </span>
+      <button
+        onClick={onClose}
+        className="ml-auto shrink-0 font-mono text-xs text-[#5A5855] hover:text-[#8A8580]"
+      >
+        Cancel
+      </button>
+    </div>
+  );
+}

--- a/apps/ooda-edge/src/components/threads/thread-shell.tsx
+++ b/apps/ooda-edge/src/components/threads/thread-shell.tsx
@@ -8,6 +8,7 @@ import { useQuery, useMutation } from "@tanstack/react-query";
 import { ChatPanel } from "./chat-panel";
 import { WorkspacePanel } from "./workspace-panel";
 import { ComparisonView } from "./comparison-view";
+import { BobDispatchBar } from "./bob-dispatch-bar";
 
 interface ThreadShellProps {
   thread: {
@@ -33,6 +34,7 @@ interface ComparisonSession {
 
 export function ThreadShell({ thread }: ThreadShellProps) {
   const [showCompareBar, setShowCompareBar] = useState(false);
+  const [showDispatchBar, setShowDispatchBar] = useState(false);
   const [workspaceOpen, setWorkspaceOpen] = useState(false);
   const [adapterA, setAdapterA] = useState("");
   const [adapterB, setAdapterB] = useState("");
@@ -129,6 +131,16 @@ export function ThreadShell({ thread }: ThreadShellProps) {
           {thread.status}
         </span>
         <button
+          onClick={() => setShowDispatchBar((v) => !v)}
+          className={`shrink-0 rounded-[3px] border px-3 py-1.5 font-mono text-xs transition-colors focus-visible:ring-2 focus-visible:ring-[#D4A04A] focus-visible:ring-offset-2 focus-visible:ring-offset-[#111113] ${
+            showDispatchBar
+              ? "border-[#D4A04A] bg-[#D4A04A]/15 text-[#D4A04A]"
+              : "border-[#2A2A2F] text-[#8A8580] hover:border-[#D4A04A] hover:text-[#D4A04A]"
+          }`}
+        >
+          Dispatch to Bob
+        </button>
+        <button
           onClick={() => setShowCompareBar((v) => !v)}
           className={`shrink-0 rounded-[3px] border px-3 py-1.5 font-mono text-xs transition-colors focus-visible:ring-2 focus-visible:ring-[#D4A04A] focus-visible:ring-offset-2 focus-visible:ring-offset-[#111113] ${
             showCompareBar || comparisonSessions
@@ -139,6 +151,14 @@ export function ThreadShell({ thread }: ThreadShellProps) {
           Compare
         </button>
       </header>
+
+      {showDispatchBar && !comparisonSessions && (
+        <BobDispatchBar
+          threadSlug={thread.slug}
+          threadId={thread.id}
+          onClose={() => setShowDispatchBar(false)}
+        />
+      )}
 
       {/* Comparison config bar */}
       {showCompareBar && !comparisonSessions && (

--- a/packages/ooda/src/api/edge-router.ts
+++ b/packages/ooda/src/api/edge-router.ts
@@ -14,6 +14,7 @@ import { runnerRouter } from "./router/runner";
 import { researchRouter } from "./router/research";
 import { oracleRouter } from "./router/oracle";
 import { importsRouter } from "./router/imports";
+import { bobRouter } from "./router/bob";
 import { createTRPCRouter } from "./trpc";
 
 const edgeRouterRecord = {
@@ -22,6 +23,9 @@ const edgeRouterRecord = {
   research: researchRouter,
   imports: importsRouter,
   oracle: oracleRouter,
+  // bob.dispatch is a pure fetch() to Bob's public API (no Node fs), so it is
+  // edge-safe and belongs on the worker that the thread UI actually talks to.
+  bob: bobRouter,
 } satisfies TRPCRouterRecord;
 
 export const edgeRouter = createTRPCRouter(edgeRouterRecord);


### PR DESCRIPTION
Ports the **Dispatch to Bob** thread action into `apps/ooda-edge` (the CF Worker that actually serves ooda.blder.bot) and registers `bob` on the edge router. The earlier apps/ooda change (#13) targeted the dev/Node copy and never reached production.

- edge-router: `bob: bobRouter` (pure fetch, edge-safe)
- thread-shell + bob-dispatch-bar: header action → inline dispatch bar → `trpc.bob.dispatch`; outcome returns as a thread note (M2)

Needs BOB_API_* wrangler secrets on ooda-blder-bot (set).

🤖 Generated with [Claude Code](https://claude.com/claude-code)