### PR TITLE
feat(ooda-edge): reframe discussion actions around Remember, demote Bob to projects

### DIFF
--- a/apps/ooda-edge/src/components/threads/bob-dispatch-bar.tsx
+++ b/apps/ooda-edge/src/components/threads/bob-dispatch-bar.tsx
@@ -48,7 +48,7 @@ export function BobDispatchBar({
   return (
     <div className="flex flex-wrap items-center gap-x-3 gap-y-2 border-b border-[#D4A04A]/40 bg-[#2E2A1A] px-4 py-2">
       <span className="shrink-0 font-mono text-xs text-[#D4A04A]">
-        Dispatch to Bob:
+        Make it a project:
       </span>
       <input
         type="text"
@@ -57,8 +57,8 @@ export function BobDispatchBar({
         onKeyDown={(e) => {
           if (e.key === "Enter" && !dispatchMutation.isPending) submit();
         }}
-        placeholder="What should Bob build?"
-        aria-label="Bob run title"
+        placeholder="What should Bob build for this project?"
+        aria-label="Project task title"
         className="min-w-0 flex-1 basis-56 rounded-[3px] border border-[#D4A04A]/30 bg-[#1A1A1E] px-2 py-1 font-mono text-xs text-[#E8E4DF] placeholder-[#5A5855] outline-none focus:border-[#D4A04A]"
       />
       <input

--- a/apps/ooda-edge/src/components/threads/chat-panel.tsx
+++ b/apps/ooda-edge/src/components/threads/chat-panel.tsx
@@ -140,6 +140,35 @@ export function ChatPanel({ threadId, runnerId, onPromoted }: ChatPanelProps) {
     });
   };
 
+  // "Remember this conversation" — the default keep gesture. Flags the whole
+  // discussion as worth keeping: the runner folds it into the vault + KB with a
+  // link back to this thread. Phase 1 promotes the transcript verbatim; the
+  // agent-distilled summary lands in a follow-up. Keyed off the latest
+  // assistant turn's session so the runner has the thread context.
+  const handleRememberConversation = () => {
+    if (!availableRunner || messages.length === 0) return;
+    const lastAssistant = [...messages]
+      .reverse()
+      .find((m) => m.role === "assistant");
+    const sessionId = lastAssistant?.id ?? activeSessionId;
+    if (!sessionId) return;
+
+    const transcript = messages
+      .map((m) => `**${m.role === "user" ? "You" : "OODA"}:** ${m.content}`)
+      .join("\n\n");
+    const firstUser = messages.find((m) => m.role === "user")?.content;
+    const title = (firstUser?.split("\n")[0]?.slice(0, 100) ?? "Remembered conversation").trim();
+
+    promoteMutation.mutate({
+      sessionId,
+      runnerId: availableRunner,
+      threadId,
+      kind: "source-extract",
+      title: title || "Remembered conversation",
+      content: transcript,
+    });
+  };
+
   const isRunning = !!activeSessionId;
 
   return (
@@ -193,6 +222,25 @@ export function ChatPanel({ threadId, runnerId, onPromoted }: ChatPanelProps) {
         {!availableRunner && (
           <div className="mb-2 rounded-[3px] bg-[#2E2A1A] px-3 py-1.5 text-xs text-amber-400">
             No runner connected. Start the runner with pnpm dev.
+          </div>
+        )}
+        {messages.length > 0 && (
+          <div className="mb-2 flex items-center justify-between gap-2 rounded-[3px] border border-[#2A2A2F] bg-[#151517] px-3 py-1.5">
+            <span className="min-w-0 truncate text-[11px] text-[#8A8580]">
+              {promoteMutation.isSuccess
+                ? "✓ Kept — folding into your vault + KB."
+                : "Worth keeping? Fold this into your vault + knowledge base."}
+            </span>
+            <button
+              type="button"
+              onClick={handleRememberConversation}
+              disabled={promoteMutation.isPending}
+              className="shrink-0 rounded-[3px] border border-[#D4A04A] bg-[#D4A04A]/15 px-3 py-1 font-mono text-xs text-[#D4A04A] transition-colors hover:bg-[#D4A04A]/25 disabled:opacity-50"
+            >
+              {promoteMutation.isPending
+                ? "Remembering…"
+                : "★ Remember this"}
+            </button>
           </div>
         )}
         <div className="flex gap-2">

--- a/apps/ooda-edge/src/components/threads/thread-shell.tsx
+++ b/apps/ooda-edge/src/components/threads/thread-shell.tsx
@@ -138,7 +138,7 @@ export function ThreadShell({ thread }: ThreadShellProps) {
               : "border-[#2A2A2F] text-[#8A8580] hover:border-[#D4A04A] hover:text-[#D4A04A]"
           }`}
         >
-          Dispatch to Bob
+          Make it a project
         </button>
         <button
           onClick={() => setShowCompareBar((v) => !v)}


### PR DESCRIPTION
Default keep gesture is now '★ Remember this' (promotes the conversation into vault+KB via the runner). 'Dispatch to Bob' is demoted/renamed to 'Make it a project' — the project path, not the every-chat action.

🤖 Generated with [Claude Code](https://claude.com/claude-code)