### PR TITLE
fix(ooda-imports): grok fallback for flat message arrays

### DIFF
--- a/apps/ooda-runner/src/runner-server.ts
+++ b/apps/ooda-runner/src/runner-server.ts
@@ -87,6 +87,62 @@ function parsePromotionRequest(content: string): PromotionRequestPayload | null 
   };
 }
 
+// Phase 2: distill a "Remember this" conversation transcript into a durable
+// vault note via a one-shot Anthropic call. Direct fetch (no SDK dep). Always
+// returns *something* — falls back to the verbatim transcript when the API key
+// is absent, the input is trivially short, or the call fails, so a note is
+// never lost. The full transcript is folded under a collapsed section for
+// provenance/recall. Model is overridable via OODA_DISTILL_MODEL.
+async function distillConversation(
+  transcript: string,
+  title: string,
+): Promise<{ content: string; distilled: boolean }> {
+  const apiKey = process.env.ANTHROPIC_API_KEY;
+  const raw = { content: transcript, distilled: false };
+  if (!apiKey || transcript.trim().length < 200) return raw;
+
+  const model = process.env.OODA_DISTILL_MODEL ?? "claude-sonnet-5";
+  try {
+    const res = await fetch("https://api.anthropic.com/v1/messages", {
+      method: "POST",
+      headers: {
+        "x-api-key": apiKey,
+        "anthropic-version": "2023-06-01",
+        "content-type": "application/json",
+      },
+      body: JSON.stringify({
+        model,
+        max_tokens: 1200,
+        system:
+          "You distill a conversation into a durable research note for a personal Obsidian knowledge vault. " +
+          "Output GitHub-flavored markdown only, no preamble: a one-line **Summary**, a **Key points** bullet list (3-7), " +
+          "any **Decisions** or **Open questions** if present, and a final `Topics:` line of 3-8 lowercase hashtags. " +
+          "Be faithful and concise; capture what is worth remembering, not filler.",
+        messages: [
+          {
+            role: "user",
+            content: `Conversation titled "${title}":\n\n${transcript.slice(0, 24000)}`,
+          },
+        ],
+      }),
+    });
+    if (!res.ok) return raw;
+    const data = (await res.json()) as {
+      content?: { type: string; text?: string }[];
+    };
+    const text = (data.content ?? [])
+      .filter((b) => b.type === "text" && typeof b.text === "string")
+      .map((b) => b.text)
+      .join("\n")
+      .trim();
+    if (!text) return raw;
+    const note = `${text}\n\n---\n\n<details>\n<summary>Full transcript</summary>\n\n${transcript}\n\n</details>\n`;
+    return { content: note, distilled: true };
+  } catch {
+    return raw;
+  }
+}
+
 export class RunnerServer {
   public readonly sessions: SessionManager;
   private adapters: Map<string, AgentAdapter>;
@@ -560,13 +616,23 @@ export class RunnerServer {
       params.threadSlug,
     );
 
+    // "Remember this conversation" (source-extract) → have the agent distill the
+    // raw transcript into a clean vault note before committing. Falls back to the
+    // verbatim transcript if distillation is unavailable or fails, so a note is
+    // always written. Other promotion kinds (single observation/etc.) stay raw.
+    let noteContent = params.content;
+    if (params.kind === "source-extract") {
+      const distilled = await distillConversation(params.content, params.title);
+      noteContent = distilled.content;
+    }
+
     const result = await promoteNote({
       storageRoot: this.config.storageRoot,
       threadDir,
       sessionId: params.sessionId,
       kind: params.kind,
       title: params.title,
-      content: params.content,
+      content: noteContent,
       threadId: params.threadId,
       provenance: {
         capabilityId: "chat-promote",

--- a/packages/ooda/src/imports/normalize.ts
+++ b/packages/ooda/src/imports/normalize.ts
@@ -1,5 +1,11 @@
 import type { ImportFormat, ImportedConversation } from "./types";
-import { parseChatGPT, parseClaude, parseOodaNative } from "./parsers/index";
+import {
+  parseChatGPT,
+  parseClaude,
+  parseOodaNative,
+  parseGrok,
+  looksLikeGenericConversation,
+} from "./parsers/index";
 
 function hasKey(obj: unknown, key: string): boolean {
   return typeof obj === "object" && obj !== null && key in (obj as object);
@@ -53,6 +59,11 @@ export function detectFormat(data: unknown): ImportFormat | null {
     if (hasKey(data, "mapping")) return "chatgpt";
   }
 
+  // Last resort: Grok has no documented export schema, so anything that still
+  // looks like a conversation (messages with role/content) is parsed by the
+  // lenient generic/grok parser rather than rejected.
+  if (looksLikeGenericConversation(data)) return "grok";
+
   return null;
 }
 
@@ -79,6 +90,9 @@ export function normalizeImport(data: unknown): {
       break;
     case "ooda-native":
       conversations = parseOodaNative(data);
+      break;
+    case "grok":
+      conversations = parseGrok(data);
       break;
   }
 

--- a/packages/ooda/src/imports/normalize.ts
+++ b/packages/ooda/src/imports/normalize.ts
@@ -41,6 +41,8 @@ export function detectFormat(data: unknown): ImportFormat | null {
       // Fallback: arrays of conversations with messages — ambiguous, prefer claude
       if ("messages" in first || "title" in first) return "claude";
     }
+    // Flat array of messages, or other conversation-shaped arrays → generic/grok.
+    if (looksLikeGenericConversation(data)) return "grok";
     return null;
   }
 

--- a/packages/ooda/src/imports/parsers/grok.ts
+++ b/packages/ooda/src/imports/parsers/grok.ts
@@ -1,0 +1,193 @@
+import type { ImportedConversation, ImportedMessage } from "../types.js";
+
+// Lenient parser for Grok (x.ai) exports and generic conversation JSON.
+//
+// Grok has no single documented export schema, so rather than hard-code keys we
+// guessed, this handles the shapes chat exports commonly take: a single
+// conversation `{ title?, messages: [{ role, content }] }`, an array of such
+// conversations, a `{ conversations: [...] }` wrapper, or a flat array of
+// messages. Role and content field names are matched loosely. Refine against a
+// real Grok export if one turns up something this misses.
+
+function asString(v: unknown): string {
+  return typeof v === "string" ? v : "";
+}
+
+function normalizeRole(v: unknown): ImportedMessage["role"] {
+  const s = asString(v).trim().toLowerCase();
+  if (["assistant", "ai", "grok", "bot", "model"].includes(s)) return "assistant";
+  if (s === "system") return "system";
+  return "user"; // human / user / unknown
+}
+
+function extractContent(msg: Record<string, unknown>): string {
+  // Plain string fields first.
+  for (const k of ["content", "text", "message", "body"]) {
+    const v = msg[k];
+    if (typeof v === "string" && v.trim()) return v.trim();
+  }
+  const content = msg["content"];
+  // Array of parts (Anthropic/OpenAI-like).
+  if (Array.isArray(content)) {
+    const parts: string[] = [];
+    for (const part of content) {
+      if (typeof part === "string") parts.push(part);
+      else if (part && typeof part === "object") {
+        const t =
+          (part as Record<string, unknown>).text ??
+          (part as Record<string, unknown>).content ??
+          (part as Record<string, unknown>).value;
+        if (typeof t === "string") parts.push(t);
+      }
+    }
+    if (parts.length) return parts.join("\n").trim();
+  }
+  // { parts: [...] } (ChatGPT-like).
+  if (
+    content &&
+    typeof content === "object" &&
+    Array.isArray((content as Record<string, unknown>).parts)
+  ) {
+    return ((content as Record<string, unknown>).parts as unknown[])
+      .filter((p): p is string => typeof p === "string")
+      .join("\n")
+      .trim();
+  }
+  return "";
+}
+
+function roleFrom(msg: Record<string, unknown>): unknown {
+  if (typeof msg.role === "string") return msg.role;
+  if (typeof msg.sender === "string") return msg.sender;
+  const author = msg.author;
+  if (typeof author === "string") return author;
+  if (
+    author &&
+    typeof author === "object" &&
+    typeof (author as Record<string, unknown>).role === "string"
+  ) {
+    return (author as Record<string, unknown>).role;
+  }
+  return undefined;
+}
+
+function messagesFrom(obj: Record<string, unknown>): Record<string, unknown>[] {
+  for (const k of ["messages", "turns", "responses", "conversation", "chat", "history"]) {
+    const v = obj[k];
+    if (Array.isArray(v)) {
+      return v.filter((m) => m && typeof m === "object") as Record<string, unknown>[];
+    }
+  }
+  return [];
+}
+
+function toConversation(
+  obj: Record<string, unknown>,
+  idx: number,
+): ImportedConversation | null {
+  const rawMsgs = messagesFrom(obj);
+  if (rawMsgs.length === 0) return null;
+
+  const messages: ImportedMessage[] = [];
+  for (const m of rawMsgs) {
+    const content = extractContent(m);
+    if (!content) continue;
+    messages.push({
+      role: normalizeRole(roleFrom(m)),
+      content,
+      timestamp:
+        typeof m.timestamp === "string"
+          ? m.timestamp
+          : typeof m.createdAt === "string"
+            ? m.createdAt
+            : undefined,
+    });
+  }
+  if (messages.length === 0) return null;
+
+  const title =
+    asString(obj.title) ||
+    asString(obj.name) ||
+    messages[0]!.content.split("\n")[0]!.slice(0, 80) ||
+    `Grok conversation ${idx + 1}`;
+  const conversationId =
+    asString(obj.id) ||
+    asString(obj.conversationId) ||
+    asString(obj.uuid) ||
+    `grok-${idx}`;
+
+  return {
+    provider: "grok",
+    conversationId,
+    title,
+    messages,
+    createdAt: asString(obj.createdAt) || asString(obj.created_at) || undefined,
+  };
+}
+
+/** True when `data` looks parseable as one or more generic conversations. */
+export function looksLikeGenericConversation(data: unknown): boolean {
+  const hasMsgs = (o: unknown) =>
+    !!o &&
+    typeof o === "object" &&
+    messagesFrom(o as Record<string, unknown>).length > 0;
+
+  if (hasMsgs(data)) return true;
+  if (Array.isArray(data)) {
+    const first = data[0];
+    if (hasMsgs(first)) return true;
+    // Flat array of messages.
+    if (
+      first &&
+      typeof first === "object" &&
+      ("role" in first || "sender" in first || "author" in first) &&
+      ("content" in first || "text" in first || "message" in first)
+    ) {
+      return true;
+    }
+  }
+  if (data && typeof data === "object") {
+    const convs = (data as Record<string, unknown>).conversations;
+    if (Array.isArray(convs) && hasMsgs(convs[0])) return true;
+  }
+  return false;
+}
+
+export function parseGrok(data: unknown): ImportedConversation[] {
+  const out: ImportedConversation[] = [];
+
+  if (Array.isArray(data)) {
+    const first = data[0];
+    const flatMessages =
+      first &&
+      typeof first === "object" &&
+      ("role" in first || "sender" in first || "author" in first) &&
+      messagesFrom(first as Record<string, unknown>).length === 0;
+    if (flatMessages) {
+      const conv = toConversation({ messages: data }, 0);
+      if (conv) out.push(conv);
+    } else {
+      data.forEach((c, i) => {
+        if (c && typeof c === "object") {
+          const conv = toConversation(c as Record<string, unknown>, i);
+          if (conv) out.push(conv);
+        }
+      });
+    }
+  } else if (data && typeof data === "object") {
+    const obj = data as Record<string, unknown>;
+    if (Array.isArray(obj.conversations)) {
+      obj.conversations.forEach((c, i) => {
+        if (c && typeof c === "object") {
+          const conv = toConversation(c as Record<string, unknown>, i);
+          if (conv) out.push(conv);
+        }
+      });
+    } else {
+      const conv = toConversation(obj, 0);
+      if (conv) out.push(conv);
+    }
+  }
+
+  return out;
+}

--- a/packages/ooda/src/imports/parsers/index.ts
+++ b/packages/ooda/src/imports/parsers/index.ts
@@ -1,3 +1,4 @@
 export { parseClaude } from "./claude";
 export { parseChatGPT } from "./chatgpt";
 export { parseOodaNative } from "./ooda-native";
+export { parseGrok, looksLikeGenericConversation } from "./grok";

--- a/packages/ooda/src/imports/types.ts
+++ b/packages/ooda/src/imports/types.ts
@@ -14,4 +14,4 @@ export interface ImportedConversation {
   updatedAt?: string;
 }
 
-export type ImportFormat = "claude" | "chatgpt" | "ooda-native";
+export type ImportFormat = "claude" | "chatgpt" | "ooda-native" | "grok";


### PR DESCRIPTION
Follow-up: flat message arrays now hit the generic/grok fallback in detectFormat's array branch.