### PR TITLE
feat: Make it a project — Bob project + backlog + create-gmacko-app scaffold (Phase 3)

### DIFF
--- a/apps/bob/src/app/api/v1/projects/route.ts
+++ b/apps/bob/src/app/api/v1/projects/route.ts
@@ -1,0 +1,25 @@
+import { NextResponse } from "next/server";
+import {
+  createPublicApiCaller,
+  errorResponse,
+  withApiRateLimit,
+} from "~/lib/rest/api-helpers";
+
+// POST /api/v1/projects — create a (linear-clone) project + seed backlog tasks.
+// The OODA "Make it a project" path. Auth + rate limiting come from the shared
+// public-API helpers; the create-gmacko-app scaffold is a separate call to
+// /api/v1/dispatch by the caller.
+export async function POST(request: Request) {
+  return withApiRateLimit(request, async () => {
+    try {
+      const caller = await createPublicApiCaller(request);
+      const body = (await request.json()) as Parameters<
+        typeof caller.publicApi.createProject
+      >[0];
+      const result = await caller.publicApi.createProject(body);
+      return NextResponse.json(result);
+    } catch (error) {
+      return errorResponse(error);
+    }
+  });
+}

--- a/apps/ooda-edge/src/components/threads/bob-dispatch-bar.tsx
+++ b/apps/ooda-edge/src/components/threads/bob-dispatch-bar.tsx
@@ -5,17 +5,14 @@ import { useState } from "react";
 import { useTRPC } from "~/trpc/react";
 import { useMutation } from "@tanstack/react-query";
 
-// Phase 5 M1 (OODA side, in-product): dispatch an executable Bob run from a
-// thread. Calls trpc.bob.dispatch, which POSTs to Bob's public /api/v1/dispatch
-// with this thread's slug/id as the correlation. When the run finishes, Bob's
-// runner writes the outcome back into this thread as a note (M2 read-back), so
-// the round-trip closes without any polling here.
+// Phase 3 — "Make it a project" (rare, project-only). Turns a discussion into a
+// real Bob (linear-clone) project: creates the project, seeds a backlog of
+// tasks, and optionally scaffolds a new app via create-gmacko-app as an
+// executable Bob dispatch. The thread slug/id ride along so any dispatched
+// scaffold reports its outcome back into this thread (M2 read-back).
 //
-// Dark until wired: if Bob dispatch env isn't configured the mutation returns
-// PRECONDITION_FAILED, and if Bob's endpoint is gated off it returns FORBIDDEN —
-// both surfaced inline so the failure is legible rather than silent.
-
-const AGENT_OPTIONS = ["auto", "claude", "grok", "codex", "cursor"] as const;
+// Dark until wired: createProject returns PRECONDITION_FAILED when Bob env is
+// unset and FORBIDDEN when Bob's dispatch is gated off — both shown inline.
 
 export function BobDispatchBar({
   threadSlug,
@@ -26,22 +23,27 @@ export function BobDispatchBar({
   threadId: string;
   onClose: () => void;
 }) {
-  const [title, setTitle] = useState("");
-  const [description, setDescription] = useState("");
-  const [agent, setAgent] = useState<(typeof AGENT_OPTIONS)[number]>("auto");
+  const [name, setName] = useState("");
+  const [tasksText, setTasksText] = useState("");
+  const [scaffold, setScaffold] = useState(false);
 
   const trpc = useTRPC();
-  const dispatchMutation = useMutation(trpc.bob.dispatch.mutationOptions());
+  const createMutation = useMutation(trpc.bob.createProject.mutationOptions());
 
   const submit = () => {
-    const trimmed = title.trim();
+    const trimmed = name.trim();
     if (!trimmed) return;
-    dispatchMutation.mutate({
+    const tasks = tasksText
+      .split(/[\n,]/)
+      .map((t) => t.trim())
+      .filter(Boolean)
+      .slice(0, 20);
+    createMutation.mutate({
       threadSlug,
       threadId,
-      title: trimmed,
-      description: description.trim() || undefined,
-      agentType: agent === "auto" ? undefined : agent,
+      name: trimmed,
+      tasks: tasks.length ? tasks : undefined,
+      scaffold,
     });
   };
 
@@ -52,63 +54,63 @@ export function BobDispatchBar({
       </span>
       <input
         type="text"
-        value={title}
-        onChange={(e) => setTitle(e.target.value)}
+        value={name}
+        onChange={(e) => setName(e.target.value)}
         onKeyDown={(e) => {
-          if (e.key === "Enter" && !dispatchMutation.isPending) submit();
+          if (e.key === "Enter" && !createMutation.isPending) submit();
         }}
-        placeholder="What should Bob build for this project?"
-        aria-label="Project task title"
-        className="min-w-0 flex-1 basis-56 rounded-[3px] border border-[#D4A04A]/30 bg-[#1A1A1E] px-2 py-1 font-mono text-xs text-[#E8E4DF] placeholder-[#5A5855] outline-none focus:border-[#D4A04A]"
+        placeholder="Project name"
+        aria-label="Project name"
+        className="min-w-0 flex-1 basis-44 rounded-[3px] border border-[#D4A04A]/30 bg-[#1A1A1E] px-2 py-1 font-mono text-xs text-[#E8E4DF] placeholder-[#5A5855] outline-none focus:border-[#D4A04A]"
       />
       <input
         type="text"
-        value={description}
-        onChange={(e) => setDescription(e.target.value)}
-        placeholder="Details (optional)"
-        aria-label="Bob run description"
-        className="min-w-0 flex-1 basis-40 rounded-[3px] border border-[#D4A04A]/30 bg-[#1A1A1E] px-2 py-1 font-mono text-xs text-[#E8E4DF] placeholder-[#5A5855] outline-none focus:border-[#D4A04A]"
+        value={tasksText}
+        onChange={(e) => setTasksText(e.target.value)}
+        placeholder="Seed tasks (comma-separated, optional)"
+        aria-label="Seed tasks"
+        className="min-w-0 flex-1 basis-52 rounded-[3px] border border-[#D4A04A]/30 bg-[#1A1A1E] px-2 py-1 font-mono text-xs text-[#E8E4DF] placeholder-[#5A5855] outline-none focus:border-[#D4A04A]"
       />
-      <select
-        value={agent}
-        onChange={(e) =>
-          setAgent(e.target.value as (typeof AGENT_OPTIONS)[number])
-        }
-        aria-label="Agent"
-        className="shrink-0 rounded-[3px] border border-[#D4A04A]/30 bg-[#1A1A1E] px-2 py-1 font-mono text-xs text-[#E8E4DF] outline-none"
-      >
-        {AGENT_OPTIONS.map((a) => (
-          <option key={a} value={a}>
-            {a}
-          </option>
-        ))}
-      </select>
+      <label className="flex shrink-0 items-center gap-1.5 font-mono text-xs text-[#8A8580]">
+        <input
+          type="checkbox"
+          checked={scaffold}
+          onChange={(e) => setScaffold(e.target.checked)}
+          className="accent-[#D4A04A]"
+        />
+        scaffold app
+      </label>
       <button
         onClick={submit}
-        disabled={!title.trim() || dispatchMutation.isPending}
+        disabled={!name.trim() || createMutation.isPending}
         className="shrink-0 rounded-[3px] bg-[#D4A04A] px-3 py-1 font-mono text-xs font-medium text-[#111113] transition-opacity hover:opacity-90 disabled:opacity-50"
       >
-        {dispatchMutation.isPending ? "Dispatching..." : "Dispatch"}
+        {createMutation.isPending ? "Creating…" : "Create project"}
       </button>
-      {/* Result / error line: aria-live so the outcome is announced. */}
+      {/* Result / error line. */}
       <span
         role="status"
         aria-live="polite"
         className="basis-full font-mono text-xs"
       >
-        {dispatchMutation.isSuccess ? (
+        {createMutation.isSuccess ? (
           <span className="text-[#6BbF59]">
-            Dispatched {dispatchMutation.data.identifier} —{" "}
-            {dispatchMutation.data.status}. Bob will post the outcome back to
-            this thread.
+            Created project {createMutation.data.key} with{" "}
+            {createMutation.data.workItems.length} task
+            {createMutation.data.workItems.length === 1 ? "" : "s"}
+            {createMutation.data.scaffold
+              ? ` — scaffold dispatched (${createMutation.data.scaffold.identifier})`
+              : scaffold
+                ? " — scaffold could not be dispatched"
+                : ""}
+            .
           </span>
-        ) : dispatchMutation.isError ? (
-          <span className="text-[#E06B6B]">
-            {dispatchMutation.error.message}
-          </span>
+        ) : createMutation.isError ? (
+          <span className="text-[#E06B6B]">{createMutation.error.message}</span>
         ) : (
           <span className="text-[#5A5855]">
-            Runs in Bob; the result returns here as a thread note.
+            Creates a Bob project + backlog. Optionally scaffolds a new app via
+            create-gmacko-app.
           </span>
         )}
       </span>

--- a/packages/bob/src/api/src/handlers/publicApi.ts
+++ b/packages/bob/src/api/src/handlers/publicApi.ts
@@ -577,6 +577,109 @@ export async function publicApiDispatchExecution(
   };
 }
 
+/**
+ * POST /projects — create a Bob (linear-clone) project and seed backlog tasks.
+ *
+ * The OODA "Make it a project" path: a discussion becomes a real project with a
+ * generated key and an initial backlog. Tenant-scoped exactly like the rest of
+ * the public API. Seeded tasks land in "backlog" (excluded from auto-drain), so
+ * nothing auto-executes without the user promoting it. The create-gmacko-app
+ * scaffold is a separate executable dispatch (publicApiDispatchExecution),
+ * kicked by the caller when requested.
+ */
+export async function publicApiCreateProject(
+  ctx: HandlerContext,
+  input: {
+    workspaceId: string;
+    name: string;
+    description?: string;
+    color?: string;
+    tasks?: string[];
+  },
+) {
+  const workspace = await ctx.db.query.workspaces.findFirst({
+    where: eq(workspaces.id, input.workspaceId),
+  });
+  if (!workspace?.tenantId) {
+    throw new TRPCError({ code: "NOT_FOUND" });
+  }
+  await assertTenantAccess(ctx.db, ctx.userId, workspace.tenantId);
+
+  // Unique project key (<=16 chars), collision-suffixed within the workspace.
+  const baseKey =
+    input.name
+      .toUpperCase()
+      .replace(/[^A-Z0-9]/g, "")
+      .slice(0, 12) || "PROJ";
+  let key = baseKey;
+  for (let suffix = 2; suffix <= 99; suffix++) {
+    const conflict = await ctx.db.query.projects.findFirst({
+      where: and(
+        eq(projects.workspaceId, input.workspaceId),
+        eq(projects.key, key),
+      ),
+      columns: { id: true },
+    });
+    if (!conflict) break;
+    key = `${baseKey}${suffix}`.slice(0, 16);
+  }
+
+  const [project] = await ctx.db
+    .insert(projects)
+    .values({
+      workspaceId: input.workspaceId,
+      name: input.name,
+      key,
+      description: input.description ?? null,
+      color: input.color ?? null,
+      status: "active",
+    })
+    .returning();
+  if (!project) {
+    throw new TRPCError({
+      code: "INTERNAL_SERVER_ERROR",
+      message: "Failed to create project",
+    });
+  }
+
+  // Seed backlog tasks.
+  const taskTitles = (input.tasks ?? [])
+    .map((t) => t.trim())
+    .filter(Boolean)
+    .slice(0, 20);
+  const createdWorkItems: { id: string; title: string }[] = [];
+  if (taskTitles.length > 0) {
+    const [{ n } = { n: 0 }] = await ctx.db
+      .select({ n: sql<number>`count(*)` })
+      .from(workItems)
+      .where(eq(workItems.workspaceId, input.workspaceId));
+    let seq = Number(n);
+    for (const title of taskTitles) {
+      seq += 1;
+      const [wi] = await ctx.db
+        .insert(workItems)
+        .values({
+          ownerUserId: ctx.userId,
+          workspaceId: input.workspaceId,
+          projectId: project.id,
+          kind: "task",
+          title: title.slice(0, 256),
+          status: "backlog",
+          sequenceNumber: seq,
+        })
+        .returning({ id: workItems.id, title: workItems.title });
+      if (wi) createdWorkItems.push(wi);
+    }
+  }
+
+  return {
+    projectId: project.id,
+    key: project.key,
+    name: project.name,
+    workItems: createdWorkItems,
+  };
+}
+
 export async function publicApiUpdateRun(
   ctx: HandlerContext,
   input: {

--- a/packages/bob/src/api/src/router/publicApi.ts
+++ b/packages/bob/src/api/src/router/publicApi.ts
@@ -11,6 +11,7 @@ import {
   publicApiRegisterWorkspace,
   publicApiCreateRun,
   publicApiDispatchExecution,
+  publicApiCreateProject,
   publicApiUpdateRun,
   publicApiCreateArtifact,
   publicApiGetRun,
@@ -86,6 +87,29 @@ export const publicApiRouter = {
     )
     .mutation(({ ctx, input }) =>
       publicApiDispatchExecution(
+        { db: ctx.db, userId: ctx.session.user.id },
+        input,
+      ),
+    ),
+
+  // POST /projects — create a (linear-clone) project + seed backlog tasks.
+  // The OODA "Make it a project" path. Scaffolding (create-gmacko-app) is a
+  // separate dispatchExecution call by the caller.
+  createProject: apiKeyWriteProcedure
+    .input(
+      z.object({
+        workspaceId: z.string().uuid(),
+        name: z.string().min(1).max(128),
+        description: z.string().max(20000).optional(),
+        color: z
+          .string()
+          .regex(/^#[0-9a-fA-F]{6}$/)
+          .optional(),
+        tasks: z.array(z.string().min(1).max(256)).max(20).optional(),
+      }),
+    )
+    .mutation(({ ctx, input }) =>
+      publicApiCreateProject(
         { db: ctx.db, userId: ctx.session.user.id },
         input,
       ),

--- a/packages/ooda/src/api/router/bob.ts
+++ b/packages/ooda/src/api/router/bob.ts
@@ -70,4 +70,104 @@ export const bobRouter = {
         status: string;
       };
     }),
+
+  // "Make it a project": create a Bob (linear-clone) project + seed backlog
+  // tasks, and optionally scaffold a new app via create-gmacko-app as an
+  // executable Bob dispatch. Same config/env as dispatch.
+  createProject: authedProcedure
+    .meta({
+      openapi: {
+        method: "POST",
+        path: "/api/bob/create-project",
+        tags: ["bob"],
+        protect: true,
+      },
+    })
+    .input(
+      z.object({
+        threadSlug: z.string().min(1).max(200),
+        threadId: z.string().max(200).optional(),
+        name: z.string().min(1).max(128),
+        description: z.string().max(20000).optional(),
+        tasks: z.array(z.string().min(1).max(256)).max(20).optional(),
+        scaffold: z.boolean().optional(),
+      }),
+    )
+    .mutation(async ({ input }) => {
+      const config = resolveBobDispatchConfig(process.env);
+      if (!config) {
+        throw new TRPCError({
+          code: "PRECONDITION_FAILED",
+          message:
+            "Bob dispatch is not configured. Set BOB_API_URL, BOB_API_KEY (a bob_live_* key), and BOB_WORKSPACE_ID.",
+        });
+      }
+
+      // 1. Create the project + seed backlog tasks.
+      const res = await fetch(`${config.apiUrl}/api/v1/projects`, {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          Authorization: `Bearer ${config.apiKey}`,
+        },
+        body: JSON.stringify({
+          workspaceId: config.workspaceId,
+          name: input.name,
+          description: input.description,
+          tasks: input.tasks,
+        }),
+      });
+      if (!res.ok) {
+        const detail = await res.text().catch(() => "");
+        throw new TRPCError({
+          code: res.status === 403 ? "FORBIDDEN" : "BAD_GATEWAY",
+          message: `Bob project create failed (${res.status}): ${detail.slice(0, 300)}`,
+        });
+      }
+      const project = (await res.json()) as {
+        projectId: string;
+        key: string;
+        name: string;
+        workItems: { id: string; title: string }[];
+      };
+
+      // 2. Optionally scaffold a new app via create-gmacko-app, as an executable
+      // dispatch. Non-fatal: a scaffold failure leaves the project + tasks intact.
+      let scaffold:
+        | { sessionId: string; identifier: string; status: string }
+        | null = null;
+      if (input.scaffold) {
+        try {
+          const dres = await fetch(`${config.apiUrl}/api/v1/dispatch`, {
+            method: "POST",
+            headers: {
+              "Content-Type": "application/json",
+              Authorization: `Bearer ${config.apiKey}`,
+            },
+            body: JSON.stringify({
+              workspaceId: config.workspaceId,
+              title: `Scaffold ${input.name} (${project.key})`,
+              description:
+                `Scaffold a new gmacko app named "${input.name}" using create-gmacko-app ` +
+                "(the create-gmacko-app-workflow skill / `npm create gmacko-app`). Set up the " +
+                "standard monorepo structure (apps, packages/ui|api|db, docs/ai). This is the " +
+                `scaffold for project ${project.key}.`,
+              agentType: "claude",
+              ooda: { threadSlug: input.threadSlug, threadId: input.threadId },
+            }),
+          });
+          if (dres.ok) {
+            scaffold = (await dres.json()) as {
+              sessionId: string;
+              identifier: string;
+              status: string;
+            };
+          }
+        } catch {
+          // Leave scaffold null; the project + tasks already succeeded.
+        }
+      }
+
+      return { ...project, scaffold };
+    }),
 } satisfies RouterRecord;


### PR DESCRIPTION
OODA 'Make it a project' now creates a Bob linear-clone project + seeds backlog tasks (new publicApi.createProject + /api/v1/projects), and optionally scaffolds a new app via create-gmacko-app as a Bob dispatch. UI: name + seed tasks + scaffold checkbox.

🤖 Generated with [Claude Code](https://claude.com/claude-code)