### PR TITLE
feat: scaffold target dir + Grok parser tests/hardening

### DIFF
--- a/packages/bob/src/api/src/handlers/publicApi.ts
+++ b/packages/bob/src/api/src/handlers/publicApi.ts
@@ -450,6 +450,20 @@ export async function publicApiCreateRun(
  * Reuses the proven headless-dispatch shape (work item -> pending execution
  * session -> gateway nudge) from dispatch.ts.
  */
+/**
+ * Constrain a caller-supplied working directory to a safe root. Dispatched
+ * agents run with elevated permissions, so the workingDirectory must stay under
+ * /home/bob/dev (where projects + scaffolds live) and contain no `..` segments.
+ * Returns the path if allowed, else undefined (caller falls back to default).
+ */
+function safeWorkingDirectory(dir: string | undefined): string | undefined {
+  if (!dir) return undefined;
+  const trimmed = dir.trim();
+  if (!trimmed.startsWith("/home/bob/dev/")) return undefined;
+  if (trimmed.includes("..")) return undefined;
+  return trimmed;
+}
+
 export async function publicApiDispatchExecution(
   ctx: HandlerContext,
   input: {
@@ -457,6 +471,7 @@ export async function publicApiDispatchExecution(
     title: string;
     description?: string;
     agentType?: string;
+    workingDirectory?: string;
     ooda?: { threadId?: string; threadSlug?: string };
   },
 ) {
@@ -515,7 +530,8 @@ export async function publicApiDispatchExecution(
   }
   const identifier = workItem.id.slice(0, 8);
 
-  const workingDirectory = "/home/bob/dev/gmacko-bob";
+  const workingDirectory =
+    safeWorkingDirectory(input.workingDirectory) ?? "/home/bob/dev/gmacko-bob";
   const [session] = await ctx.db
     .insert(chatConversations)
     .values({

--- a/packages/bob/src/api/src/router/publicApi.ts
+++ b/packages/bob/src/api/src/router/publicApi.ts
@@ -71,6 +71,10 @@ export const publicApiRouter = {
         title: z.string().min(1).max(500),
         description: z.string().max(20000).optional(),
         agentType: z.string().min(1).max(64).optional(),
+        // Optional working directory for the run (validated server-side to stay
+        // under /home/bob/dev). Used by "Make it a project" scaffolds so
+        // create-gmacko-app runs in a fresh project dir, not the bob monorepo.
+        workingDirectory: z.string().max(512).optional(),
         // Opaque OODA correlation for M2 read-back. threadSlug is the thread
         // workspace directory (what the runner resolves); threadId is the UUID
         // for provenance/entity extraction. At least one is required.

--- a/packages/ooda/src/api/router/bob.ts
+++ b/packages/ooda/src/api/router/bob.ts
@@ -147,11 +147,15 @@ export const bobRouter = {
             body: JSON.stringify({
               workspaceId: config.workspaceId,
               title: `Scaffold ${input.name} (${project.key})`,
+              // Fresh per-project dir, outside the bob monorepo (so the scaffold
+              // creates a standalone app and no stray PR against bob).
+              workingDirectory: "/home/bob/dev/projects",
               description:
-                `Scaffold a new gmacko app named "${input.name}" using create-gmacko-app ` +
-                "(the create-gmacko-app-workflow skill / `npm create gmacko-app`). Set up the " +
-                "standard monorepo structure (apps, packages/ui|api|db, docs/ai). This is the " +
-                `scaffold for project ${project.key}.`,
+                `You are in /home/bob/dev/projects. Create a new subdirectory named ` +
+                `"${project.key.toLowerCase()}" and scaffold a new gmacko app named "${input.name}" ` +
+                "inside it using create-gmacko-app (the create-gmacko-app-workflow skill / " +
+                "`npm create gmacko-app`). Set up the standard monorepo structure " +
+                `(apps, packages/ui|api|db, docs/ai). This is the scaffold for project ${project.key}.`,
               agentType: "claude",
               ooda: { threadSlug: input.threadSlug, threadId: input.threadId },
             }),

--- a/packages/ooda/src/imports/parsers/__tests__/grok.test.ts
+++ b/packages/ooda/src/imports/parsers/__tests__/grok.test.ts
@@ -1,0 +1,95 @@
+import { describe, expect, it } from "vitest";
+
+import { parseGrok } from "../grok.js";
+import { normalizeImport } from "../../normalize.js";
+
+describe("parseGrok", () => {
+  it("parses a single conversation with role/content messages", () => {
+    const convs = parseGrok({
+      title: "Rocket engines",
+      messages: [
+        { role: "user", content: "How do aerospike nozzles work?" },
+        { role: "assistant", content: "They stay efficient across altitudes." },
+      ],
+    });
+    expect(convs).toHaveLength(1);
+    expect(convs[0]!.provider).toBe("grok");
+    expect(convs[0]!.title).toBe("Rocket engines");
+    expect(convs[0]!.messages.map((m) => m.role)).toEqual(["user", "assistant"]);
+  });
+
+  it("parses a flat array of messages", () => {
+    const convs = parseGrok([
+      { role: "user", content: "first" },
+      { role: "assistant", content: "second" },
+    ]);
+    expect(convs).toHaveLength(1);
+    expect(convs[0]!.messages).toHaveLength(2);
+    expect(convs[0]!.messages[1]!.role).toBe("assistant");
+  });
+
+  it("handles sender/text fields and Grok-style roles (AGENT/USER)", () => {
+    const convs = parseGrok({
+      messages: [
+        { sender: "USER", text: "hi" },
+        { sender: "AGENT", text: "hello" },
+      ],
+    });
+    expect(convs[0]!.messages.map((m) => m.role)).toEqual([
+      "user",
+      "assistant",
+    ]);
+  });
+
+  it("handles author.role + content.parts (OpenAI-ish) shape", () => {
+    const convs = parseGrok({
+      messages: [
+        { author: { role: "user" }, content: { parts: ["question"] } },
+        { author: { role: "assistant" }, content: { parts: ["answer"] } },
+      ],
+    });
+    expect(convs[0]!.messages[0]!.content).toBe("question");
+    expect(convs[0]!.messages[1]!.role).toBe("assistant");
+  });
+
+  it("unwraps a { conversations: [...] } envelope", () => {
+    const convs = parseGrok({
+      conversations: [
+        { title: "A", messages: [{ role: "user", content: "x" }] },
+        { title: "B", messages: [{ role: "user", content: "y" }] },
+      ],
+    });
+    expect(convs).toHaveLength(2);
+    expect(convs.map((c) => c.title)).toEqual(["A", "B"]);
+  });
+
+  it("reads alternate message container keys (history/turns)", () => {
+    const convs = parseGrok({
+      history: [
+        { role: "user", content: "q" },
+        { role: "grok", content: "a" },
+      ],
+    });
+    expect(convs[0]!.messages.map((m) => m.role)).toEqual(["user", "assistant"]);
+  });
+});
+
+describe("normalizeImport with grok fallback", () => {
+  it("detects a generic conversation as grok", () => {
+    const { format, conversations } = normalizeImport({
+      title: "T",
+      messages: [{ role: "user", content: "hi" }],
+    });
+    expect(format).toBe("grok");
+    expect(conversations).toHaveLength(1);
+  });
+
+  it("does not hijack a ChatGPT export", () => {
+    const { format } = normalizeImport({ mapping: {} });
+    expect(format).toBe("chatgpt");
+  });
+
+  it("still rejects non-conversation junk", () => {
+    expect(() => normalizeImport({ random: "junk" })).toThrow();
+  });
+});

--- a/packages/ooda/src/imports/parsers/grok.ts
+++ b/packages/ooda/src/imports/parsers/grok.ts
@@ -15,7 +15,11 @@ function asString(v: unknown): string {
 
 function normalizeRole(v: unknown): ImportedMessage["role"] {
   const s = asString(v).trim().toLowerCase();
-  if (["assistant", "ai", "grok", "bot", "model"].includes(s)) return "assistant";
+  if (
+    ["assistant", "ai", "grok", "bot", "model", "agent", "gpt"].includes(s)
+  ) {
+    return "assistant";
+  }
   if (s === "system") return "system";
   return "user"; // human / user / unknown
 }


### PR DESCRIPTION
Scaffold now targets a fresh /home/bob/dev/projects/<key> dir (validated workingDirectory on dispatch), standalone outside the bob monorepo. Grok parser: role hardening + 9 unit tests. Real Grok export still wanted to verify field mapping.