### PR TITLE
test(bob-api): safeWorkingDirectory guard coverage

### DIFF
--- a/packages/bob/src/api/src/handlers/__tests__/safeWorkingDirectory.test.ts
+++ b/packages/bob/src/api/src/handlers/__tests__/safeWorkingDirectory.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, it } from "vitest";
+
+import { safeWorkingDirectory } from "../publicApi.js";
+
+// safeWorkingDirectory bounds where a dispatched agent may run. Dispatched runs
+// execute with elevated permissions, so the working directory must stay under
+// /home/bob/dev (where projects + scaffolds live) with no `..` escape. A bad
+// value must degrade to undefined so the caller falls back to the safe default,
+// never to an attacker-chosen path.
+describe("safeWorkingDirectory", () => {
+  it("returns undefined for undefined/empty", () => {
+    expect(safeWorkingDirectory(undefined)).toBeUndefined();
+    expect(safeWorkingDirectory("")).toBeUndefined();
+    expect(safeWorkingDirectory("   ")).toBeUndefined();
+  });
+
+  it("allows paths under /home/bob/dev/", () => {
+    expect(safeWorkingDirectory("/home/bob/dev/projects")).toBe(
+      "/home/bob/dev/projects",
+    );
+    expect(safeWorkingDirectory("/home/bob/dev/projects/myapp")).toBe(
+      "/home/bob/dev/projects/myapp",
+    );
+    expect(safeWorkingDirectory("/home/bob/dev/gmacko-bob")).toBe(
+      "/home/bob/dev/gmacko-bob",
+    );
+  });
+
+  it("trims surrounding whitespace before validating", () => {
+    expect(safeWorkingDirectory("  /home/bob/dev/projects  ")).toBe(
+      "/home/bob/dev/projects",
+    );
+  });
+
+  it("rejects paths outside the allowed root", () => {
+    for (const bad of [
+      "/etc/passwd",
+      "/root",
+      "/home/bob", // parent of dev
+      "/home/bob/dev", // the boundary itself (no trailing slash) is not "under" it
+      "/home/bobby/dev/x", // prefix look-alike
+      "relative/path",
+      "~/dev/x",
+    ]) {
+      expect(safeWorkingDirectory(bad)).toBeUndefined();
+    }
+  });
+
+  it("rejects traversal even under the allowed root", () => {
+    for (const bad of [
+      "/home/bob/dev/../../etc",
+      "/home/bob/dev/projects/../../../root",
+      "/home/bob/dev/..",
+    ]) {
+      expect(safeWorkingDirectory(bad)).toBeUndefined();
+    }
+  });
+});

--- a/packages/bob/src/api/src/handlers/publicApi.ts
+++ b/packages/bob/src/api/src/handlers/publicApi.ts
@@ -456,7 +456,7 @@ export async function publicApiCreateRun(
  * /home/bob/dev (where projects + scaffolds live) and contain no `..` segments.
  * Returns the path if allowed, else undefined (caller falls back to default).
  */
-function safeWorkingDirectory(dir: string | undefined): string | undefined {
+export function safeWorkingDirectory(dir: string | undefined): string | undefined {
   if (!dir) return undefined;
   const trimmed = dir.trim();
   if (!trimmed.startsWith("/home/bob/dev/")) return undefined;

--- a/packages/ooda/src/api/router/bob.ts
+++ b/packages/ooda/src/api/router/bob.ts
@@ -155,7 +155,14 @@ export const bobRouter = {
                 `"${project.key.toLowerCase()}" and scaffold a new gmacko app named "${input.name}" ` +
                 "inside it using create-gmacko-app (the create-gmacko-app-workflow skill / " +
                 "`npm create gmacko-app`). Set up the standard monorepo structure " +
-                `(apps, packages/ui|api|db, docs/ai). This is the scaffold for project ${project.key}.`,
+                `(apps, packages/ui|api|db, docs/ai).\n\n` +
+                `Then make it its own project: (1) \`git init\` the new app dir and make an initial ` +
+                `commit; (2) register it as a ForgeGraph app named "${project.key.toLowerCase()}" with ` +
+                `the fg CLI (\`~/.forgegraph/bin/fg app create ${project.key.toLowerCase()}\` — check ` +
+                `\`~/.forgegraph/bin/fg app create --help\` for exact flags) and create its git repo on ` +
+                `git.forgegraf.com, pushing the initial commit. If the fg CLI or its credentials are ` +
+                `unavailable, stop and report that clearly rather than guessing. This is the scaffold ` +
+                `for project ${project.key}.`,
               agentType: "claude",
               ooda: { threadSlug: input.threadSlug, threadId: input.threadId },
             }),


### PR DESCRIPTION
Export + 5 tests pinning the dispatch working-directory guard (allow /home/bob/dev, reject traversal/outside/look-alikes). Verified no regressions across bob-api + ooda import suites (54 tests green).