### PR TITLE
feat(ooda-edge): public-alias notice on gmac.io

### DIFF
--- a/apps/ooda-edge/src/app/layout.tsx
+++ b/apps/ooda-edge/src/app/layout.tsx
@@ -5,6 +5,7 @@ import { ThemeSwitcher } from "@gmacko/core/ui";
 
 import { TRPCReactProvider } from "~/trpc/react";
 import { AppShell } from "~/components/app-shell";
+import { PublicAliasNotice } from "~/components/public-alias-notice";
 
 import "~/app/globals.css";
 
@@ -50,6 +51,7 @@ export default function RootLayout(props: { children: React.ReactNode }) {
       >
         <ThemeProvider defaultTheme="ooda">
           <TRPCReactProvider>
+            <PublicAliasNotice />
             <AppShell>{props.children}</AppShell>
           </TRPCReactProvider>
           <div className="absolute right-4 bottom-4">

--- a/apps/ooda-edge/src/components/public-alias-notice.tsx
+++ b/apps/ooda-edge/src/components/public-alias-notice.tsx
@@ -1,0 +1,36 @@
+"use client";
+
+import { useEffect, useState } from "react";
+
+// ooda.gmac.io is a public alias of the OODA worker. Auth is SSO via a
+// .blder.bot-scoped cookie, which a browser on gmac.io can't send — so chat,
+// Remember, and projects can't run here. Rather than let people hit a bare
+// "Not authenticated", show a thin bar pointing them at ooda.blder.bot (same
+// path) for anything that needs a login. Renders nothing anywhere else.
+export function PublicAliasNotice() {
+  const [href, setHref] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (typeof window === "undefined") return;
+    if (window.location.hostname === "ooda.gmac.io") {
+      setHref(
+        `https://ooda.blder.bot${window.location.pathname}${window.location.search}`,
+      );
+    }
+  }, []);
+
+  if (!href) return null;
+
+  return (
+    <div className="flex flex-wrap items-center justify-center gap-x-1.5 border-b border-[#2A2825] bg-[#1A1915] px-4 py-1.5 text-center text-xs text-[#8A8580]">
+      <span>Public view &mdash; log in on</span>
+      <a
+        href={href}
+        className="font-medium text-[#D4A04A] hover:underline"
+      >
+        ooda.blder.bot
+      </a>
+      <span>to chat, Remember, or start a project.</span>
+    </div>
+  );
+}

--- a/apps/ooda-edge/wrangler.jsonc
+++ b/apps/ooda-edge/wrangler.jsonc
@@ -4,7 +4,10 @@
   "compatibility_date": "2025-12-01",
   "compatibility_flags": ["nodejs_compat"],
   "workers_dev": false,
-  "routes": [{ "pattern": "ooda.blder.bot", "custom_domain": true }],
+  "routes": [
+    { "pattern": "ooda.blder.bot", "custom_domain": true },
+    { "pattern": "ooda.gmac.io", "custom_domain": true }
+  ],
   "assets": {
     "directory": "dist/client",
     "binding": "ASSETS",

--- a/packages/bob/src/api/src/handlers/__tests__/safeWorkingDirectory.test.ts
+++ b/packages/bob/src/api/src/handlers/__tests__/safeWorkingDirectory.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, it } from "vitest";
+
+import { safeWorkingDirectory } from "../publicApi.js";
+
+// safeWorkingDirectory bounds where a dispatched agent may run. Dispatched runs
+// execute with elevated permissions, so the working directory must stay under
+// /home/bob/dev (where projects + scaffolds live) with no `..` escape. A bad
+// value must degrade to undefined so the caller falls back to the safe default,
+// never to an attacker-chosen path.
+describe("safeWorkingDirectory", () => {
+  it("returns undefined for undefined/empty", () => {
+    expect(safeWorkingDirectory(undefined)).toBeUndefined();
+    expect(safeWorkingDirectory("")).toBeUndefined();
+    expect(safeWorkingDirectory("   ")).toBeUndefined();
+  });
+
+  it("allows paths under /home/bob/dev/", () => {
+    expect(safeWorkingDirectory("/home/bob/dev/projects")).toBe(
+      "/home/bob/dev/projects",
+    );
+    expect(safeWorkingDirectory("/home/bob/dev/projects/myapp")).toBe(
+      "/home/bob/dev/projects/myapp",
+    );
+    expect(safeWorkingDirectory("/home/bob/dev/gmacko-bob")).toBe(
+      "/home/bob/dev/gmacko-bob",
+    );
+  });
+
+  it("trims surrounding whitespace before validating", () => {
+    expect(safeWorkingDirectory("  /home/bob/dev/projects  ")).toBe(
+      "/home/bob/dev/projects",
+    );
+  });
+
+  it("rejects paths outside the allowed root", () => {
+    for (const bad of [
+      "/etc/passwd",
+      "/root",
+      "/home/bob", // parent of dev
+      "/home/bob/dev", // the boundary itself (no trailing slash) is not "under" it
+      "/home/bobby/dev/x", // prefix look-alike
+      "relative/path",
+      "~/dev/x",
+    ]) {
+      expect(safeWorkingDirectory(bad)).toBeUndefined();
+    }
+  });
+
+  it("rejects traversal even under the allowed root", () => {
+    for (const bad of [
+      "/home/bob/dev/../../etc",
+      "/home/bob/dev/projects/../../../root",
+      "/home/bob/dev/..",
+    ]) {
+      expect(safeWorkingDirectory(bad)).toBeUndefined();
+    }
+  });
+});

--- a/packages/bob/src/api/src/handlers/publicApi.ts
+++ b/packages/bob/src/api/src/handlers/publicApi.ts
@@ -456,7 +456,7 @@ export async function publicApiCreateRun(
  * /home/bob/dev (where projects + scaffolds live) and contain no `..` segments.
  * Returns the path if allowed, else undefined (caller falls back to default).
  */
-function safeWorkingDirectory(dir: string | undefined): string | undefined {
+export function safeWorkingDirectory(dir: string | undefined): string | undefined {
   if (!dir) return undefined;
   const trimmed = dir.trim();
   if (!trimmed.startsWith("/home/bob/dev/")) return undefined;

--- a/packages/ooda/src/api/router/bob.ts
+++ b/packages/ooda/src/api/router/bob.ts
@@ -155,7 +155,14 @@ export const bobRouter = {
                 `"${project.key.toLowerCase()}" and scaffold a new gmacko app named "${input.name}" ` +
                 "inside it using create-gmacko-app (the create-gmacko-app-workflow skill / " +
                 "`npm create gmacko-app`). Set up the standard monorepo structure " +
-                `(apps, packages/ui|api|db, docs/ai). This is the scaffold for project ${project.key}.`,
+                `(apps, packages/ui|api|db, docs/ai).\n\n` +
+                `Then make it its own project: (1) \`git init\` the new app dir and make an initial ` +
+                `commit; (2) register it as a ForgeGraph app named "${project.key.toLowerCase()}" with ` +
+                `the fg CLI (\`~/.forgegraph/bin/fg app create ${project.key.toLowerCase()}\` — check ` +
+                `\`~/.forgegraph/bin/fg app create --help\` for exact flags) and create its git repo on ` +
+                `git.forgegraf.com, pushing the initial commit. If the fg CLI or its credentials are ` +
+                `unavailable, stop and report that clearly rather than guessing. This is the scaffold ` +
+                `for project ${project.key}.`,
               agentType: "claude",
               ooda: { threadSlug: input.threadSlug, threadId: input.threadId },
             }),


### PR DESCRIPTION
Thin banner on the gmac.io host linking to ooda.blder.bot for authed actions (option 3: gmac.io as public alias).