### PR TITLE
feat(ooda-edge): cross-domain SSO for ooda.gmac.io

### DIFF
--- a/apps/ooda-edge/src/app/api/sso/accept/route.ts
+++ b/apps/ooda-edge/src/app/api/sso/accept/route.ts
@@ -1,0 +1,42 @@
+import { verifyEnvelope, SESSION_COOKIE } from "~/lib/sso";
+
+// GET /api/sso/accept?t=<envelope>&r=<return url> — accept side of the SSO.
+// Runs on ooda.gmac.io. Verifies the HMAC envelope minted by ooda.blder.bot and
+// sets a .gmac.io session cookie carrying the same signed better-auth token, so
+// getSession authenticates this domain against the shared session DB. A missing
+// or invalid/expired envelope just returns to the page with ?sso=none (no
+// cookie set) — the client then shows the login notice instead of looping.
+export async function GET(request: Request): Promise<Response> {
+  const url = new URL(request.url);
+  const rawReturn = url.searchParams.get("r") ?? "/oracle";
+  let redirectTo: URL;
+  try {
+    redirectTo = new URL(rawReturn, "https://ooda.gmac.io");
+    if (redirectTo.hostname !== "ooda.gmac.io") {
+      redirectTo = new URL("https://ooda.gmac.io/oracle");
+    }
+  } catch {
+    redirectTo = new URL("https://ooda.gmac.io/oracle");
+  }
+
+  const token = url.searchParams.get("t");
+  const secret = process.env.AUTH_SECRET ?? "";
+  const value = token && secret ? await verifyEnvelope(token, secret) : null;
+
+  if (!value) {
+    redirectTo.searchParams.set("sso", "none");
+    return Response.redirect(redirectTo.toString(), 302);
+  }
+
+  // Clear any prior ?sso=none marker on success.
+  redirectTo.searchParams.delete("sso");
+
+  const cookie =
+    `${SESSION_COOKIE}=${value}; Domain=.gmac.io; Path=/; Secure; HttpOnly; ` +
+    `SameSite=Lax; Max-Age=604800`;
+
+  return new Response(null, {
+    status: 302,
+    headers: { "Set-Cookie": cookie, Location: redirectTo.toString() },
+  });
+}

--- a/apps/ooda-edge/src/app/api/sso/handoff/route.ts
+++ b/apps/ooda-edge/src/app/api/sso/handoff/route.ts
@@ -1,0 +1,36 @@
+import { signEnvelope, readSessionCookieValue } from "~/lib/sso";
+
+// GET /api/sso/handoff?r=<return url> — mint side of the cross-domain SSO.
+// Called on ooda.blder.bot (which holds the .blder.bot session). Reads the
+// current session token, wraps it in a signed envelope, and redirects to
+// ooda.gmac.io/api/sso/accept. If there is no session here, redirects back with
+// ?sso=none so gmac.io stops retrying and shows the "log in" notice instead.
+export async function GET(request: Request): Promise<Response> {
+  const url = new URL(request.url);
+  const rawReturn = url.searchParams.get("r") ?? "https://ooda.gmac.io/oracle";
+  // Only ever return to the gmac.io alias.
+  let returnUrl: URL;
+  try {
+    returnUrl = new URL(rawReturn, "https://ooda.gmac.io");
+    if (returnUrl.hostname !== "ooda.gmac.io") {
+      returnUrl = new URL("https://ooda.gmac.io/oracle");
+    }
+  } catch {
+    returnUrl = new URL("https://ooda.gmac.io/oracle");
+  }
+
+  const secret = process.env.AUTH_SECRET ?? "";
+  const sessionValue = readSessionCookieValue(request.headers.get("cookie") ?? "");
+
+  const accept = new URL("https://ooda.gmac.io/api/sso/accept");
+  accept.searchParams.set("r", returnUrl.toString());
+
+  if (sessionValue && secret) {
+    accept.searchParams.set("t", await signEnvelope(sessionValue, secret));
+  } else {
+    // Not logged in on blder.bot either → don't hand off a token.
+    accept.searchParams.set("sso", "none");
+  }
+
+  return Response.redirect(accept.toString(), 302);
+}

--- a/apps/ooda-edge/src/app/api/sso/status/route.ts
+++ b/apps/ooda-edge/src/app/api/sso/status/route.ts
@@ -1,0 +1,14 @@
+import { getAuth } from "~/auth/server";
+
+// GET /api/sso/status — { authed: boolean } for the current request cookies.
+// The client on ooda.gmac.io uses this to decide whether to trigger the SSO
+// handoff, show the login notice, or do nothing. Validates the session token
+// against the shared DB via better-auth (domain-agnostic).
+export async function GET(request: Request): Promise<Response> {
+  try {
+    const session = await getAuth().api.getSession({ headers: request.headers });
+    return Response.json({ authed: Boolean(session?.session) });
+  } catch {
+    return Response.json({ authed: false });
+  }
+}

--- a/apps/ooda-edge/src/app/layout.tsx
+++ b/apps/ooda-edge/src/app/layout.tsx
@@ -5,6 +5,7 @@ import { ThemeSwitcher } from "@gmacko/core/ui";
 
 import { TRPCReactProvider } from "~/trpc/react";
 import { AppShell } from "~/components/app-shell";
+import { PublicAliasNotice } from "~/components/public-alias-notice";
 
 import "~/app/globals.css";
 
@@ -50,6 +51,7 @@ export default function RootLayout(props: { children: React.ReactNode }) {
       >
         <ThemeProvider defaultTheme="ooda">
           <TRPCReactProvider>
+            <PublicAliasNotice />
             <AppShell>{props.children}</AppShell>
           </TRPCReactProvider>
           <div className="absolute right-4 bottom-4">

--- a/apps/ooda-edge/src/auth/server.ts
+++ b/apps/ooda-edge/src/auth/server.ts
@@ -19,6 +19,8 @@ export function getAuth(): AuthInstance {
       "https://blder.bot",
       "https://bob.blder.bot",
       "https://ooda.blder.bot",
+      // Public alias — SSO-linked to ooda.blder.bot via /api/sso/*.
+      "https://ooda.gmac.io",
       ...(process.env.TRUSTED_ORIGINS?.split(",").map((o) => o.trim()) ?? []),
     ];
 

--- a/apps/ooda-edge/src/components/public-alias-notice.tsx
+++ b/apps/ooda-edge/src/components/public-alias-notice.tsx
@@ -2,32 +2,54 @@
 
 import { useEffect, useState } from "react";
 
-// ooda.gmac.io is a public alias of the OODA worker. Auth is SSO via a
-// .blder.bot-scoped cookie, which a browser on gmac.io can't send — so chat,
-// Remember, and projects can't run here. Rather than let people hit a bare
-// "Not authenticated", show a thin bar pointing them at ooda.blder.bot (same
-// path) for anything that needs a login. Renders nothing anywhere else.
+// On ooda.gmac.io, single-sign-on with ooda.blder.bot: check auth, and if not
+// authenticated, bounce once through the blder.bot handoff (which sets a
+// matching .gmac.io session cookie). Only if that comes back empty (?sso=none —
+// not logged in on blder.bot either) do we show a login notice, so there's no
+// redirect loop. Renders nothing on ooda.blder.bot or once authenticated.
+type State = "off" | "checking" | "authed" | "needs-login";
+
 export function PublicAliasNotice() {
-  const [href, setHref] = useState<string | null>(null);
+  const [state, setState] = useState<State>("off");
 
   useEffect(() => {
     if (typeof window === "undefined") return;
-    if (window.location.hostname === "ooda.gmac.io") {
-      setHref(
-        `https://ooda.blder.bot${window.location.pathname}${window.location.search}`,
-      );
-    }
+    if (window.location.hostname !== "ooda.gmac.io") return;
+
+    setState("checking");
+    fetch("/api/sso/status", { credentials: "include" })
+      .then((r) => r.json() as Promise<{ authed?: boolean }>)
+      .then((d) => {
+        if (d.authed) {
+          setState("authed");
+          return;
+        }
+        // Not authed. If we already tried the handoff (?sso=none), stop and
+        // show the notice; otherwise bounce through blder.bot once.
+        const tried =
+          new URLSearchParams(window.location.search).get("sso") === "none";
+        if (tried) {
+          setState("needs-login");
+          return;
+        }
+        const back = encodeURIComponent(window.location.href);
+        window.location.replace(
+          `https://ooda.blder.bot/api/sso/handoff?r=${back}`,
+        );
+      })
+      .catch(() => setState("needs-login"));
   }, []);
 
-  if (!href) return null;
+  if (state !== "needs-login") return null;
+
+  const loginHref = `https://ooda.blder.bot${
+    typeof window !== "undefined" ? window.location.pathname : "/oracle"
+  }`;
 
   return (
     <div className="flex flex-wrap items-center justify-center gap-x-1.5 border-b border-[#2A2825] bg-[#1A1915] px-4 py-1.5 text-center text-xs text-[#8A8580]">
-      <span>Public view &mdash; log in on</span>
-      <a
-        href={href}
-        className="font-medium text-[#D4A04A] hover:underline"
-      >
+      <span>Not signed in &mdash; log in on</span>
+      <a href={loginHref} className="font-medium text-[#D4A04A] hover:underline">
         ooda.blder.bot
       </a>
       <span>to chat, Remember, or start a project.</span>

--- a/apps/ooda-edge/src/components/public-alias-notice.tsx
+++ b/apps/ooda-edge/src/components/public-alias-notice.tsx
@@ -1,0 +1,36 @@
+"use client";
+
+import { useEffect, useState } from "react";
+
+// ooda.gmac.io is a public alias of the OODA worker. Auth is SSO via a
+// .blder.bot-scoped cookie, which a browser on gmac.io can't send — so chat,
+// Remember, and projects can't run here. Rather than let people hit a bare
+// "Not authenticated", show a thin bar pointing them at ooda.blder.bot (same
+// path) for anything that needs a login. Renders nothing anywhere else.
+export function PublicAliasNotice() {
+  const [href, setHref] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (typeof window === "undefined") return;
+    if (window.location.hostname === "ooda.gmac.io") {
+      setHref(
+        `https://ooda.blder.bot${window.location.pathname}${window.location.search}`,
+      );
+    }
+  }, []);
+
+  if (!href) return null;
+
+  return (
+    <div className="flex flex-wrap items-center justify-center gap-x-1.5 border-b border-[#2A2825] bg-[#1A1915] px-4 py-1.5 text-center text-xs text-[#8A8580]">
+      <span>Public view &mdash; log in on</span>
+      <a
+        href={href}
+        className="font-medium text-[#D4A04A] hover:underline"
+      >
+        ooda.blder.bot
+      </a>
+      <span>to chat, Remember, or start a project.</span>
+    </div>
+  );
+}

--- a/apps/ooda-edge/src/lib/sso.ts
+++ b/apps/ooda-edge/src/lib/sso.ts
@@ -1,0 +1,111 @@
+// Cross-domain SSO handoff between ooda.blder.bot (auth home) and ooda.gmac.io.
+//
+// A single cookie can't span both registrable domains, so we propagate the
+// already-signed better-auth session token: ooda.blder.bot reads its own
+// session cookie, wraps the token value in a short-lived HMAC-signed envelope
+// (signed with the shared AUTH_SECRET, so it can't be forged in the URL), and
+// ooda.gmac.io verifies the envelope and sets a matching .gmac.io session
+// cookie. getSession then validates that token against the shared DB — no new
+// session is minted, and logout on blder.bot (DB session delete) revokes both.
+
+const enc = new TextEncoder();
+
+/** Envelope validity window. Short — it only needs to survive one redirect. */
+const TTL_MS = 60_000;
+
+/** Session cookie better-auth issues over HTTPS (Secure prefix in prod). */
+export const SESSION_COOKIE = "__Secure-better-auth.session_token" as const;
+
+/** All prefixes better-auth may use, most-secure first. */
+const SESSION_COOKIE_NAMES = [
+  "__Secure-better-auth.session_token",
+  "__Host-better-auth.session_token",
+  "better-auth.session_token",
+] as const;
+
+function b64url(bytes: Uint8Array): string {
+  const s = btoa(String.fromCharCode(...bytes));
+  return s.replace(/\+/g, "-").replace(/\//g, "_").replace(/=+$/g, "");
+}
+
+function b64urlDecode(str: string): Uint8Array {
+  const s = str.replace(/-/g, "+").replace(/_/g, "/");
+  const bin = atob(s);
+  const out = new Uint8Array(bin.length);
+  for (let i = 0; i < bin.length; i++) out[i] = bin.charCodeAt(i);
+  return out;
+}
+
+async function hmacKey(secret: string): Promise<CryptoKey> {
+  return crypto.subtle.importKey(
+    "raw",
+    enc.encode(secret),
+    { name: "HMAC", hash: "SHA-256" },
+    false,
+    ["sign", "verify"],
+  );
+}
+
+/** Sign a session-token value into a short-lived transport envelope. */
+export async function signEnvelope(
+  value: string,
+  secret: string,
+): Promise<string> {
+  const payload = enc.encode(JSON.stringify({ v: value, exp: Date.now() + TTL_MS }));
+  const key = await hmacKey(secret);
+  const sig = new Uint8Array(
+    await crypto.subtle.sign("HMAC", key, payload as BufferSource),
+  );
+  return `${b64url(payload)}.${b64url(sig)}`;
+}
+
+/**
+ * Verify an envelope and return the session-token value, or null if the
+ * signature is invalid, the shape is wrong, or it has expired. crypto.subtle
+ * .verify does a constant-time comparison, so there's no timing side channel.
+ */
+export async function verifyEnvelope(
+  token: string,
+  secret: string,
+): Promise<string | null> {
+  const parts = token.split(".");
+  if (parts.length !== 2) return null;
+  let payload: Uint8Array;
+  let sig: Uint8Array;
+  try {
+    payload = b64urlDecode(parts[0]!);
+    sig = b64urlDecode(parts[1]!);
+  } catch {
+    return null;
+  }
+  const key = await hmacKey(secret);
+  const ok = await crypto.subtle.verify(
+    "HMAC",
+    key,
+    sig as BufferSource,
+    payload as BufferSource,
+  );
+  if (!ok) return null;
+  try {
+    const parsed = JSON.parse(new TextDecoder().decode(payload)) as {
+      v?: unknown;
+      exp?: unknown;
+    };
+    if (typeof parsed.exp !== "number" || Date.now() > parsed.exp) return null;
+    if (typeof parsed.v !== "string" || parsed.v.length === 0) return null;
+    return parsed.v;
+  } catch {
+    return null;
+  }
+}
+
+/** Read the better-auth session cookie value (any prefix) from a Cookie header. */
+export function readSessionCookieValue(cookieHeader: string): string | null {
+  const pairs = cookieHeader.split(";").map((c) => c.trim());
+  for (const name of SESSION_COOKIE_NAMES) {
+    for (const pair of pairs) {
+      if (pair.startsWith(`${name}=`)) return pair.slice(name.length + 1);
+    }
+  }
+  return null;
+}

--- a/apps/ooda-edge/wrangler.jsonc
+++ b/apps/ooda-edge/wrangler.jsonc
@@ -4,7 +4,10 @@
   "compatibility_date": "2025-12-01",
   "compatibility_flags": ["nodejs_compat"],
   "workers_dev": false,
-  "routes": [{ "pattern": "ooda.blder.bot", "custom_domain": true }],
+  "routes": [
+    { "pattern": "ooda.blder.bot", "custom_domain": true },
+    { "pattern": "ooda.gmac.io", "custom_domain": true }
+  ],
   "assets": {
     "directory": "dist/client",
     "binding": "ASSETS",

--- a/packages/bob/src/api/src/handlers/__tests__/safeWorkingDirectory.test.ts
+++ b/packages/bob/src/api/src/handlers/__tests__/safeWorkingDirectory.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, it } from "vitest";
+
+import { safeWorkingDirectory } from "../publicApi.js";
+
+// safeWorkingDirectory bounds where a dispatched agent may run. Dispatched runs
+// execute with elevated permissions, so the working directory must stay under
+// /home/bob/dev (where projects + scaffolds live) with no `..` escape. A bad
+// value must degrade to undefined so the caller falls back to the safe default,
+// never to an attacker-chosen path.
+describe("safeWorkingDirectory", () => {
+  it("returns undefined for undefined/empty", () => {
+    expect(safeWorkingDirectory(undefined)).toBeUndefined();
+    expect(safeWorkingDirectory("")).toBeUndefined();
+    expect(safeWorkingDirectory("   ")).toBeUndefined();
+  });
+
+  it("allows paths under /home/bob/dev/", () => {
+    expect(safeWorkingDirectory("/home/bob/dev/projects")).toBe(
+      "/home/bob/dev/projects",
+    );
+    expect(safeWorkingDirectory("/home/bob/dev/projects/myapp")).toBe(
+      "/home/bob/dev/projects/myapp",
+    );
+    expect(safeWorkingDirectory("/home/bob/dev/gmacko-bob")).toBe(
+      "/home/bob/dev/gmacko-bob",
+    );
+  });
+
+  it("trims surrounding whitespace before validating", () => {
+    expect(safeWorkingDirectory("  /home/bob/dev/projects  ")).toBe(
+      "/home/bob/dev/projects",
+    );
+  });
+
+  it("rejects paths outside the allowed root", () => {
+    for (const bad of [
+      "/etc/passwd",
+      "/root",
+      "/home/bob", // parent of dev
+      "/home/bob/dev", // the boundary itself (no trailing slash) is not "under" it
+      "/home/bobby/dev/x", // prefix look-alike
+      "relative/path",
+      "~/dev/x",
+    ]) {
+      expect(safeWorkingDirectory(bad)).toBeUndefined();
+    }
+  });
+
+  it("rejects traversal even under the allowed root", () => {
+    for (const bad of [
+      "/home/bob/dev/../../etc",
+      "/home/bob/dev/projects/../../../root",
+      "/home/bob/dev/..",
+    ]) {
+      expect(safeWorkingDirectory(bad)).toBeUndefined();
+    }
+  });
+});

--- a/packages/bob/src/api/src/handlers/publicApi.ts
+++ b/packages/bob/src/api/src/handlers/publicApi.ts
@@ -456,7 +456,7 @@ export async function publicApiCreateRun(
  * /home/bob/dev (where projects + scaffolds live) and contain no `..` segments.
  * Returns the path if allowed, else undefined (caller falls back to default).
  */
-function safeWorkingDirectory(dir: string | undefined): string | undefined {
+export function safeWorkingDirectory(dir: string | undefined): string | undefined {
   if (!dir) return undefined;
   const trimmed = dir.trim();
   if (!trimmed.startsWith("/home/bob/dev/")) return undefined;

--- a/packages/ooda/src/api/router/bob.ts
+++ b/packages/ooda/src/api/router/bob.ts
@@ -155,7 +155,14 @@ export const bobRouter = {
                 `"${project.key.toLowerCase()}" and scaffold a new gmacko app named "${input.name}" ` +
                 "inside it using create-gmacko-app (the create-gmacko-app-workflow skill / " +
                 "`npm create gmacko-app`). Set up the standard monorepo structure " +
-                `(apps, packages/ui|api|db, docs/ai). This is the scaffold for project ${project.key}.`,
+                `(apps, packages/ui|api|db, docs/ai).\n\n` +
+                `Then make it its own project: (1) \`git init\` the new app dir and make an initial ` +
+                `commit; (2) register it as a ForgeGraph app named "${project.key.toLowerCase()}" with ` +
+                `the fg CLI (\`~/.forgegraph/bin/fg app create ${project.key.toLowerCase()}\` — check ` +
+                `\`~/.forgegraph/bin/fg app create --help\` for exact flags) and create its git repo on ` +
+                `git.forgegraf.com, pushing the initial commit. If the fg CLI or its credentials are ` +
+                `unavailable, stop and report that clearly rather than guessing. This is the scaffold ` +
+                `for project ${project.key}.`,
               agentType: "claude",
               ooda: { threadSlug: input.threadSlug, threadId: input.threadId },
             }),


### PR DESCRIPTION
Log in once on ooda.blder.bot -> ooda.gmac.io authenticates via a secure HMAC session-token handoff that sets a matching .gmac.io cookie. No GitHub OAuth change. Loop-guarded auto-trigger + login-notice fallback.