### PR TITLE
feat(ooda-imports): real Grok export parser + bulk importer

### DIFF
--- a/apps/ooda-edge/src/app/api/sso/accept/route.ts
+++ b/apps/ooda-edge/src/app/api/sso/accept/route.ts
@@ -1,0 +1,42 @@
+import { verifyEnvelope, SESSION_COOKIE } from "~/lib/sso";
+
+// GET /api/sso/accept?t=<envelope>&r=<return url> — accept side of the SSO.
+// Runs on ooda.gmac.io. Verifies the HMAC envelope minted by ooda.blder.bot and
+// sets a .gmac.io session cookie carrying the same signed better-auth token, so
+// getSession authenticates this domain against the shared session DB. A missing
+// or invalid/expired envelope just returns to the page with ?sso=none (no
+// cookie set) — the client then shows the login notice instead of looping.
+export async function GET(request: Request): Promise<Response> {
+  const url = new URL(request.url);
+  const rawReturn = url.searchParams.get("r") ?? "/oracle";
+  let redirectTo: URL;
+  try {
+    redirectTo = new URL(rawReturn, "https://ooda.gmac.io");
+    if (redirectTo.hostname !== "ooda.gmac.io") {
+      redirectTo = new URL("https://ooda.gmac.io/oracle");
+    }
+  } catch {
+    redirectTo = new URL("https://ooda.gmac.io/oracle");
+  }
+
+  const token = url.searchParams.get("t");
+  const secret = process.env.AUTH_SECRET ?? "";
+  const value = token && secret ? await verifyEnvelope(token, secret) : null;
+
+  if (!value) {
+    redirectTo.searchParams.set("sso", "none");
+    return Response.redirect(redirectTo.toString(), 302);
+  }
+
+  // Clear any prior ?sso=none marker on success.
+  redirectTo.searchParams.delete("sso");
+
+  const cookie =
+    `${SESSION_COOKIE}=${value}; Domain=.gmac.io; Path=/; Secure; HttpOnly; ` +
+    `SameSite=Lax; Max-Age=604800`;
+
+  return new Response(null, {
+    status: 302,
+    headers: { "Set-Cookie": cookie, Location: redirectTo.toString() },
+  });
+}

--- a/apps/ooda-edge/src/app/api/sso/handoff/route.ts
+++ b/apps/ooda-edge/src/app/api/sso/handoff/route.ts
@@ -1,0 +1,36 @@
+import { signEnvelope, readSessionCookieValue } from "~/lib/sso";
+
+// GET /api/sso/handoff?r=<return url> — mint side of the cross-domain SSO.
+// Called on ooda.blder.bot (which holds the .blder.bot session). Reads the
+// current session token, wraps it in a signed envelope, and redirects to
+// ooda.gmac.io/api/sso/accept. If there is no session here, redirects back with
+// ?sso=none so gmac.io stops retrying and shows the "log in" notice instead.
+export async function GET(request: Request): Promise<Response> {
+  const url = new URL(request.url);
+  const rawReturn = url.searchParams.get("r") ?? "https://ooda.gmac.io/oracle";
+  // Only ever return to the gmac.io alias.
+  let returnUrl: URL;
+  try {
+    returnUrl = new URL(rawReturn, "https://ooda.gmac.io");
+    if (returnUrl.hostname !== "ooda.gmac.io") {
+      returnUrl = new URL("https://ooda.gmac.io/oracle");
+    }
+  } catch {
+    returnUrl = new URL("https://ooda.gmac.io/oracle");
+  }
+
+  const secret = process.env.AUTH_SECRET ?? "";
+  const sessionValue = readSessionCookieValue(request.headers.get("cookie") ?? "");
+
+  const accept = new URL("https://ooda.gmac.io/api/sso/accept");
+  accept.searchParams.set("r", returnUrl.toString());
+
+  if (sessionValue && secret) {
+    accept.searchParams.set("t", await signEnvelope(sessionValue, secret));
+  } else {
+    // Not logged in on blder.bot either → don't hand off a token.
+    accept.searchParams.set("sso", "none");
+  }
+
+  return Response.redirect(accept.toString(), 302);
+}

--- a/apps/ooda-edge/src/app/api/sso/status/route.ts
+++ b/apps/ooda-edge/src/app/api/sso/status/route.ts
@@ -1,0 +1,14 @@
+import { getAuth } from "~/auth/server";
+
+// GET /api/sso/status — { authed: boolean } for the current request cookies.
+// The client on ooda.gmac.io uses this to decide whether to trigger the SSO
+// handoff, show the login notice, or do nothing. Validates the session token
+// against the shared DB via better-auth (domain-agnostic).
+export async function GET(request: Request): Promise<Response> {
+  try {
+    const session = await getAuth().api.getSession({ headers: request.headers });
+    return Response.json({ authed: Boolean(session?.session) });
+  } catch {
+    return Response.json({ authed: false });
+  }
+}

--- a/apps/ooda-edge/src/auth/server.ts
+++ b/apps/ooda-edge/src/auth/server.ts
@@ -19,6 +19,8 @@ export function getAuth(): AuthInstance {
       "https://blder.bot",
       "https://bob.blder.bot",
       "https://ooda.blder.bot",
+      // Public alias — SSO-linked to ooda.blder.bot via /api/sso/*.
+      "https://ooda.gmac.io",
       ...(process.env.TRUSTED_ORIGINS?.split(",").map((o) => o.trim()) ?? []),
     ];
 

--- a/apps/ooda-edge/src/components/public-alias-notice.tsx
+++ b/apps/ooda-edge/src/components/public-alias-notice.tsx
@@ -2,32 +2,54 @@
 
 import { useEffect, useState } from "react";
 
-// ooda.gmac.io is a public alias of the OODA worker. Auth is SSO via a
-// .blder.bot-scoped cookie, which a browser on gmac.io can't send — so chat,
-// Remember, and projects can't run here. Rather than let people hit a bare
-// "Not authenticated", show a thin bar pointing them at ooda.blder.bot (same
-// path) for anything that needs a login. Renders nothing anywhere else.
+// On ooda.gmac.io, single-sign-on with ooda.blder.bot: check auth, and if not
+// authenticated, bounce once through the blder.bot handoff (which sets a
+// matching .gmac.io session cookie). Only if that comes back empty (?sso=none —
+// not logged in on blder.bot either) do we show a login notice, so there's no
+// redirect loop. Renders nothing on ooda.blder.bot or once authenticated.
+type State = "off" | "checking" | "authed" | "needs-login";
+
 export function PublicAliasNotice() {
-  const [href, setHref] = useState<string | null>(null);
+  const [state, setState] = useState<State>("off");
 
   useEffect(() => {
     if (typeof window === "undefined") return;
-    if (window.location.hostname === "ooda.gmac.io") {
-      setHref(
-        `https://ooda.blder.bot${window.location.pathname}${window.location.search}`,
-      );
-    }
+    if (window.location.hostname !== "ooda.gmac.io") return;
+
+    setState("checking");
+    fetch("/api/sso/status", { credentials: "include" })
+      .then((r) => r.json() as Promise<{ authed?: boolean }>)
+      .then((d) => {
+        if (d.authed) {
+          setState("authed");
+          return;
+        }
+        // Not authed. If we already tried the handoff (?sso=none), stop and
+        // show the notice; otherwise bounce through blder.bot once.
+        const tried =
+          new URLSearchParams(window.location.search).get("sso") === "none";
+        if (tried) {
+          setState("needs-login");
+          return;
+        }
+        const back = encodeURIComponent(window.location.href);
+        window.location.replace(
+          `https://ooda.blder.bot/api/sso/handoff?r=${back}`,
+        );
+      })
+      .catch(() => setState("needs-login"));
   }, []);
 
-  if (!href) return null;
+  if (state !== "needs-login") return null;
+
+  const loginHref = `https://ooda.blder.bot${
+    typeof window !== "undefined" ? window.location.pathname : "/oracle"
+  }`;
 
   return (
     <div className="flex flex-wrap items-center justify-center gap-x-1.5 border-b border-[#2A2825] bg-[#1A1915] px-4 py-1.5 text-center text-xs text-[#8A8580]">
-      <span>Public view &mdash; log in on</span>
-      <a
-        href={href}
-        className="font-medium text-[#D4A04A] hover:underline"
-      >
+      <span>Not signed in &mdash; log in on</span>
+      <a href={loginHref} className="font-medium text-[#D4A04A] hover:underline">
         ooda.blder.bot
       </a>
       <span>to chat, Remember, or start a project.</span>

--- a/apps/ooda-edge/src/lib/sso.ts
+++ b/apps/ooda-edge/src/lib/sso.ts
@@ -1,0 +1,111 @@
+// Cross-domain SSO handoff between ooda.blder.bot (auth home) and ooda.gmac.io.
+//
+// A single cookie can't span both registrable domains, so we propagate the
+// already-signed better-auth session token: ooda.blder.bot reads its own
+// session cookie, wraps the token value in a short-lived HMAC-signed envelope
+// (signed with the shared AUTH_SECRET, so it can't be forged in the URL), and
+// ooda.gmac.io verifies the envelope and sets a matching .gmac.io session
+// cookie. getSession then validates that token against the shared DB — no new
+// session is minted, and logout on blder.bot (DB session delete) revokes both.
+
+const enc = new TextEncoder();
+
+/** Envelope validity window. Short — it only needs to survive one redirect. */
+const TTL_MS = 60_000;
+
+/** Session cookie better-auth issues over HTTPS (Secure prefix in prod). */
+export const SESSION_COOKIE = "__Secure-better-auth.session_token" as const;
+
+/** All prefixes better-auth may use, most-secure first. */
+const SESSION_COOKIE_NAMES = [
+  "__Secure-better-auth.session_token",
+  "__Host-better-auth.session_token",
+  "better-auth.session_token",
+] as const;
+
+function b64url(bytes: Uint8Array): string {
+  const s = btoa(String.fromCharCode(...bytes));
+  return s.replace(/\+/g, "-").replace(/\//g, "_").replace(/=+$/g, "");
+}
+
+function b64urlDecode(str: string): Uint8Array {
+  const s = str.replace(/-/g, "+").replace(/_/g, "/");
+  const bin = atob(s);
+  const out = new Uint8Array(bin.length);
+  for (let i = 0; i < bin.length; i++) out[i] = bin.charCodeAt(i);
+  return out;
+}
+
+async function hmacKey(secret: string): Promise<CryptoKey> {
+  return crypto.subtle.importKey(
+    "raw",
+    enc.encode(secret),
+    { name: "HMAC", hash: "SHA-256" },
+    false,
+    ["sign", "verify"],
+  );
+}
+
+/** Sign a session-token value into a short-lived transport envelope. */
+export async function signEnvelope(
+  value: string,
+  secret: string,
+): Promise<string> {
+  const payload = enc.encode(JSON.stringify({ v: value, exp: Date.now() + TTL_MS }));
+  const key = await hmacKey(secret);
+  const sig = new Uint8Array(
+    await crypto.subtle.sign("HMAC", key, payload as BufferSource),
+  );
+  return `${b64url(payload)}.${b64url(sig)}`;
+}
+
+/**
+ * Verify an envelope and return the session-token value, or null if the
+ * signature is invalid, the shape is wrong, or it has expired. crypto.subtle
+ * .verify does a constant-time comparison, so there's no timing side channel.
+ */
+export async function verifyEnvelope(
+  token: string,
+  secret: string,
+): Promise<string | null> {
+  const parts = token.split(".");
+  if (parts.length !== 2) return null;
+  let payload: Uint8Array;
+  let sig: Uint8Array;
+  try {
+    payload = b64urlDecode(parts[0]!);
+    sig = b64urlDecode(parts[1]!);
+  } catch {
+    return null;
+  }
+  const key = await hmacKey(secret);
+  const ok = await crypto.subtle.verify(
+    "HMAC",
+    key,
+    sig as BufferSource,
+    payload as BufferSource,
+  );
+  if (!ok) return null;
+  try {
+    const parsed = JSON.parse(new TextDecoder().decode(payload)) as {
+      v?: unknown;
+      exp?: unknown;
+    };
+    if (typeof parsed.exp !== "number" || Date.now() > parsed.exp) return null;
+    if (typeof parsed.v !== "string" || parsed.v.length === 0) return null;
+    return parsed.v;
+  } catch {
+    return null;
+  }
+}
+
+/** Read the better-auth session cookie value (any prefix) from a Cookie header. */
+export function readSessionCookieValue(cookieHeader: string): string | null {
+  const pairs = cookieHeader.split(";").map((c) => c.trim());
+  for (const name of SESSION_COOKIE_NAMES) {
+    for (const pair of pairs) {
+      if (pair.startsWith(`${name}=`)) return pair.slice(name.length + 1);
+    }
+  }
+  return null;
+}

--- a/packages/ooda/src/imports/normalize.ts
+++ b/packages/ooda/src/imports/normalize.ts
@@ -5,6 +5,7 @@ import {
   parseOodaNative,
   parseGrok,
   looksLikeGenericConversation,
+  isGrokBackendExport,
 } from "./parsers/index";
 
 function hasKey(obj: unknown, key: string): boolean {
@@ -16,6 +17,11 @@ function hasKey(obj: unknown, key: string): boolean {
  * the structure does not match any known format.
  */
 export function detectFormat(data: unknown): ImportFormat | null {
+  // Real Grok account export: { conversations: [{ conversation, responses }] }.
+  // Checked first because its `conversations` key would otherwise be misread as
+  // ChatGPT.
+  if (isGrokBackendExport(data)) return "grok";
+
   // OODA native: flat array where entries have sessionId + type + content
   if (Array.isArray(data)) {
     const first = data[0];

--- a/packages/ooda/src/imports/parsers/__tests__/grok.test.ts
+++ b/packages/ooda/src/imports/parsers/__tests__/grok.test.ts
@@ -74,6 +74,69 @@ describe("parseGrok", () => {
   });
 });
 
+describe("parseGrok — real account export (prod-grok-backend)", () => {
+  const backend = {
+    conversations: [
+      {
+        conversation: {
+          id: "3fce291c-331b-4e90-ab32-ca1629034399",
+          title: "Enterprise AI Pricing",
+          create_time: "2026-08-06T11:49:24.823545Z",
+        },
+        responses: [
+          {
+            response: {
+              _id: "a1",
+              message: "what is enterprise ai pricing?",
+              sender: "human",
+              create_time: { $date: { $numberLong: "1786016990579" } },
+            },
+          },
+          {
+            response: {
+              _id: "a2",
+              message: "Direct agreements exist with the model vendors.",
+              sender: "ASSISTANT",
+              create_time: { $date: { $numberLong: "1786016995000" } },
+            },
+          },
+          // A response with no message (tool/empty) is skipped.
+          { response: { _id: "a3", message: "", sender: "assistant" } },
+        ],
+      },
+    ],
+  };
+
+  it("parses the nested conversation/responses shape", () => {
+    const convs = parseGrok(backend);
+    expect(convs).toHaveLength(1);
+    expect(convs[0]!.provider).toBe("grok");
+    expect(convs[0]!.title).toBe("Enterprise AI Pricing");
+    expect(convs[0]!.conversationId).toBe(
+      "3fce291c-331b-4e90-ab32-ca1629034399",
+    );
+    // 2 messages (the empty one is dropped); sender human→user, ASSISTANT→assistant
+    expect(convs[0]!.messages.map((m) => m.role)).toEqual(["user", "assistant"]);
+    expect(convs[0]!.messages[0]!.content).toBe(
+      "what is enterprise ai pricing?",
+    );
+  });
+
+  it("converts Mongo $date timestamps to ISO", () => {
+    const convs = parseGrok(backend);
+    expect(convs[0]!.messages[0]!.timestamp).toBe(
+      new Date(1786016990579).toISOString(),
+    );
+    expect(convs[0]!.createdAt).toBe("2026-08-06T11:49:24.823545Z");
+  });
+
+  it("normalizeImport detects the backend export as grok, not chatgpt", () => {
+    const { format, conversations } = normalizeImport(backend);
+    expect(format).toBe("grok");
+    expect(conversations[0]!.messages).toHaveLength(2);
+  });
+});
+
 describe("normalizeImport with grok fallback", () => {
   it("detects a generic conversation as grok", () => {
     const { format, conversations } = normalizeImport({

--- a/packages/ooda/src/imports/parsers/grok.ts
+++ b/packages/ooda/src/imports/parsers/grok.ts
@@ -157,7 +157,98 @@ export function looksLikeGenericConversation(data: unknown): boolean {
   return false;
 }
 
+// --- Real Grok account-export ("prod-grok-backend") format --------------------
+// Shape: { conversations: [ { conversation: {id,title,create_time,...},
+//   responses: [ { response: {message, sender, create_time, model, ...} } ] } ] }
+// Roles: sender is "human" | "assistant" (any case). Message text is a string on
+// `response.message`. Responses form a tree (parent_response_id/path) but we
+// keep every response that carries text, in listed order — good enough for KB
+// ingestion, and avoids dropping regenerated branches.
+
+interface GrokBackendEntry {
+  conversation?: Record<string, unknown>;
+  responses?: unknown[];
+}
+
+/** True for the real Grok account export (nested conversation/responses). */
+export function isGrokBackendExport(data: unknown): boolean {
+  if (!data || typeof data !== "object") return false;
+  const convs = (data as Record<string, unknown>).conversations;
+  if (!Array.isArray(convs) || convs.length === 0) return false;
+  const first = convs[0];
+  return (
+    !!first &&
+    typeof first === "object" &&
+    "conversation" in first &&
+    "responses" in first
+  );
+}
+
+function grokBackendTime(v: unknown): string | undefined {
+  if (typeof v === "string") return v;
+  // Mongo extended JSON: { $date: { $numberLong: "…ms" } }
+  if (v && typeof v === "object") {
+    const d = (v as Record<string, unknown>).$date;
+    const ms =
+      d && typeof d === "object"
+        ? (d as Record<string, unknown>).$numberLong
+        : undefined;
+    if (typeof ms === "string" && /^\d+$/.test(ms)) {
+      return new Date(Number(ms)).toISOString();
+    }
+  }
+  return undefined;
+}
+
+function parseGrokBackend(data: unknown): ImportedConversation[] {
+  const convs = (data as Record<string, unknown>).conversations as unknown[];
+  const out: ImportedConversation[] = [];
+
+  convs.forEach((raw, idx) => {
+    if (!raw || typeof raw !== "object") return;
+    const entry = raw as GrokBackendEntry;
+    const conv = (entry.conversation ?? {}) as Record<string, unknown>;
+    const responses = Array.isArray(entry.responses) ? entry.responses : [];
+
+    const messages: ImportedMessage[] = [];
+    for (const r of responses) {
+      const resp =
+        r && typeof r === "object"
+          ? ((r as Record<string, unknown>).response as
+              | Record<string, unknown>
+              | undefined)
+          : undefined;
+      if (!resp) continue;
+      const content = asString(resp.message).trim();
+      if (!content) continue;
+      messages.push({
+        role: normalizeRole(resp.sender),
+        content,
+        timestamp: grokBackendTime(resp.create_time),
+      });
+    }
+    if (messages.length === 0) return;
+
+    const title =
+      asString(conv.title) ||
+      messages[0]!.content.split("\n")[0]!.slice(0, 80) ||
+      `Grok conversation ${idx + 1}`;
+    out.push({
+      provider: "grok",
+      conversationId: asString(conv.id) || `grok-${idx}`,
+      title,
+      messages,
+      createdAt: grokBackendTime(conv.create_time),
+    });
+  });
+
+  return out;
+}
+
 export function parseGrok(data: unknown): ImportedConversation[] {
+  // Real account export first.
+  if (isGrokBackendExport(data)) return parseGrokBackend(data);
+
   const out: ImportedConversation[] = [];
 
   if (Array.isArray(data)) {

--- a/packages/ooda/src/imports/parsers/index.ts
+++ b/packages/ooda/src/imports/parsers/index.ts
@@ -1,4 +1,4 @@
 export { parseClaude } from "./claude";
 export { parseChatGPT } from "./chatgpt";
 export { parseOodaNative } from "./ooda-native";
-export { parseGrok, looksLikeGenericConversation } from "./grok";
+export { parseGrok, looksLikeGenericConversation, isGrokBackendExport } from "./grok";

--- a/scripts/import-grok-export.ts
+++ b/scripts/import-grok-export.ts
@@ -1,0 +1,193 @@
+/**
+ * Bulk-import a Grok account export (prod-grok-backend.json) into the OODA
+ * research-vault KB. The export is huge (100s of MB), so we STREAM it and
+ * bracket-match one conversation entry at a time — never loading the whole file
+ * — then reuse the tested parser + source-record shaper and upsert into
+ * research_vault.sources (dedup on (kind, external_id)).
+ *
+ * Usage:
+ *   DATABASE_URL=postgres://… npx tsx scripts/import-grok-export.ts <path-to/prod-grok-backend.json> [--dry-run] [--batch=500]
+ *
+ * --dry-run parses + counts only (no DB, no DATABASE_URL needed). Run it first
+ * to sanity-check the counts.
+ */
+import { createReadStream } from "node:fs";
+
+import { parseGrok } from "../packages/ooda/src/imports/parsers/grok.js";
+import { conversationToSourceRecord } from "../packages/ooda/src/imports/to-source-record.js";
+
+const args = process.argv.slice(2);
+const file = args.find((a) => !a.startsWith("--"));
+const dryRun = args.includes("--dry-run");
+// --emit-sql: write upsert SQL to stdout instead of connecting (pipe to psql on
+// a host that can reach the DB). All progress/log lines go to stderr so stdout
+// stays pure SQL.
+const emitSql = args.includes("--emit-sql");
+const batchSize = Number(
+  args.find((a) => a.startsWith("--batch="))?.split("=")[1] ?? 500,
+);
+
+const sqlStr = (v: string | null | undefined): string =>
+  v === null || v === undefined ? "NULL" : `'${String(v).replace(/'/g, "''")}'`;
+
+if (!file) {
+  console.error("usage: tsx scripts/import-grok-export.ts <file> [--dry-run] [--batch=N]");
+  process.exit(1);
+}
+
+type SourceRow = ReturnType<typeof conversationToSourceRecord>;
+
+async function main() {
+  // Lazy DB setup — not needed for --dry-run / --emit-sql.
+  let insertBatch: (rows: SourceRow[]) => Promise<void> = async () => {};
+  let closeDb: () => Promise<void> = async () => {};
+  if (emitSql) {
+    insertBatch = async (rows) => {
+      if (rows.length === 0) return;
+      const values = rows
+        .map(
+          (r) =>
+            `(${sqlStr(r.kind)}, ${sqlStr(r.externalId)}, ${sqlStr(r.title)}, ` +
+            `${sqlStr(r.body)}, ${sqlStr(r.contentHash)}, ${sqlStr(r.author ?? null)}, ` +
+            `${r.sourceTs ? `${sqlStr(new Date(r.sourceTs).toISOString())}::timestamptz` : "NULL"})`,
+        )
+        .join(",\n");
+      process.stdout.write(
+        `insert into research_vault.sources (kind, external_id, title, body, content_hash, author, source_ts) values\n${values}\n` +
+          `on conflict (kind, external_id) do update set title = excluded.title, body = excluded.body, content_hash = excluded.content_hash;\n`,
+      );
+    };
+  } else if (!dryRun) {
+    const url = process.env.DATABASE_URL;
+    if (!url) {
+      console.error("DATABASE_URL is required (or pass --dry-run)");
+      process.exit(1);
+    }
+    const postgres = (await import("postgres")).default;
+    const sql = postgres(url, { max: 4 });
+    closeDb = () => sql.end({ timeout: 5 });
+    insertBatch = async (rows) => {
+      if (rows.length === 0) return;
+      // Upsert each row; ON CONFLICT keeps the KB idempotent across re-runs.
+      await sql`
+        insert into research_vault.sources
+          (kind, external_id, title, body, content_hash, author, source_ts)
+        values ${sql(
+          rows.map((r) => [
+            r.kind,
+            r.externalId,
+            r.title,
+            r.body,
+            r.contentHash,
+            r.author ?? null,
+            r.sourceTs ? new Date(r.sourceTs) : null,
+          ]),
+        )}
+        on conflict (kind, external_id) do update
+          set title = excluded.title,
+              body = excluded.body,
+              content_hash = excluded.content_hash
+      `;
+    };
+  }
+
+  let convCount = 0;
+  let msgCount = 0;
+  let inserted = 0;
+  let pending: SourceRow[] = [];
+
+  const flush = async () => {
+    if (pending.length === 0) return;
+    await insertBatch(pending);
+    inserted += pending.length;
+    pending = [];
+    process.stderr.write(`\r  processed ${inserted} conversations…`);
+  };
+
+  // Handle one streamed conversation entry (raw JSON text of a single object).
+  const handleEntry = async (entryJson: string) => {
+    let entry: unknown;
+    try {
+      entry = JSON.parse(entryJson);
+    } catch {
+      return; // skip malformed entry
+    }
+    const convs = parseGrok({ conversations: [entry] });
+    for (const conv of convs) {
+      convCount += 1;
+      msgCount += conv.messages.length;
+      if (!dryRun) {
+        pending.push(conversationToSourceRecord(conv));
+        if (pending.length >= batchSize) await flush();
+      }
+    }
+  };
+
+  // Streaming bracket-matcher: after the `conversations` array's opening `[`,
+  // capture each top-level {...} object (respecting strings/escapes).
+  await new Promise<void>((resolve, reject) => {
+    const stream = createReadStream(file, { encoding: "utf8" });
+    let started = false; // seen the opening '['
+    let depth = 0;
+    let inStr = false;
+    let esc = false;
+    let cur = "";
+    let chain: Promise<void> = Promise.resolve();
+
+    stream.on("data", (chunk: string | Buffer) => {
+      const text = typeof chunk === "string" ? chunk : chunk.toString("utf8");
+      for (let i = 0; i < text.length; i++) {
+        const c = text[i]!;
+        if (!started) {
+          if (c === "[") started = true;
+          continue;
+        }
+        if (inStr) {
+          cur += c;
+          if (esc) esc = false;
+          else if (c === "\\") esc = true;
+          else if (c === '"') inStr = false;
+          continue;
+        }
+        if (c === '"') {
+          inStr = true;
+          cur += c;
+          continue;
+        }
+        if (c === "{") {
+          depth += 1;
+          cur += c;
+          continue;
+        }
+        if (c === "}") {
+          depth -= 1;
+          cur += c;
+          if (depth === 0) {
+            const entryJson = cur;
+            cur = "";
+            chain = chain.then(() => handleEntry(entryJson));
+          }
+          continue;
+        }
+        if (depth > 0) cur += c;
+      }
+    });
+    stream.on("end", () => {
+      chain.then(resolve).catch(reject);
+    });
+    stream.on("error", reject);
+  });
+
+  await flush();
+  await closeDb();
+  process.stderr.write("\n");
+  console.error(
+    `${dryRun ? "[dry-run] " : emitSql ? "[emit-sql] " : ""}parsed ${convCount} conversations, ${msgCount} messages` +
+      (dryRun || emitSql ? "" : `, upserted ${inserted} into research_vault.sources`),
+  );
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});


### PR DESCRIPTION
Finalized Grok parser against a real 213MB prod-grok-backend export (nested conversation/responses, human/assistant, Mongo dates). +3 tests (12 green). Streaming import script (--dry-run/--emit-sql/direct). Loaded 361 conversations into the KB.