### PR TITLE
feat: OODA agent Bob/Kanbanger task tools + Bob create-work-item/list-projects API

### DIFF
--- a/apps/bob/src/app/api/v1/projects/route.ts
+++ b/apps/bob/src/app/api/v1/projects/route.ts
@@ -23,3 +23,18 @@ export async function POST(request: Request) {
     }
   });
 }
+
+// GET /api/v1/projects?workspaceId=… — list a workspace's projects.
+export async function GET(request: Request) {
+  return withApiRateLimit(request, async () => {
+    try {
+      const caller = await createPublicApiCaller(request);
+      const workspaceId =
+        new URL(request.url).searchParams.get("workspaceId") ?? "";
+      const result = await caller.publicApi.listProjects({ workspaceId });
+      return NextResponse.json(result);
+    } catch (error) {
+      return errorResponse(error);
+    }
+  });
+}

--- a/apps/bob/src/app/api/v1/work-items/create/route.ts
+++ b/apps/bob/src/app/api/v1/work-items/create/route.ts
@@ -1,0 +1,23 @@
+import { NextResponse } from "next/server";
+import {
+  createPublicApiCaller,
+  errorResponse,
+  withApiRateLimit,
+} from "~/lib/rest/api-helpers";
+
+// POST /api/v1/work-items/create — create a single task, optionally under a
+// project. Used by the OODA conversation agent's Kanbanger tool.
+export async function POST(request: Request) {
+  return withApiRateLimit(request, async () => {
+    try {
+      const caller = await createPublicApiCaller(request);
+      const body = (await request.json()) as Parameters<
+        typeof caller.publicApi.createWorkItem
+      >[0];
+      const result = await caller.publicApi.createWorkItem(body);
+      return NextResponse.json(result);
+    } catch (error) {
+      return errorResponse(error);
+    }
+  });
+}

--- a/packages/bob/src/api/src/handlers/publicApi.ts
+++ b/packages/bob/src/api/src/handlers/publicApi.ts
@@ -696,6 +696,101 @@ export async function publicApiCreateProject(
   };
 }
 
+/**
+ * GET /projects — list a workspace's (linear-clone) projects. Lets an agent /
+ * caller discover active projects to file tasks against.
+ */
+export async function publicApiListProjects(
+  ctx: HandlerContext,
+  input: { workspaceId: string },
+) {
+  const workspace = await ctx.db.query.workspaces.findFirst({
+    where: eq(workspaces.id, input.workspaceId),
+  });
+  if (!workspace?.tenantId) {
+    throw new TRPCError({ code: "NOT_FOUND" });
+  }
+  await assertTenantAccess(ctx.db, ctx.userId, workspace.tenantId);
+
+  const rows = await ctx.db.query.projects.findMany({
+    where: eq(projects.workspaceId, input.workspaceId),
+    columns: { id: true, key: true, name: true, status: true },
+    orderBy: desc(projects.createdAt),
+    limit: 100,
+  });
+  return { projects: rows };
+}
+
+/**
+ * POST /work-items — create a single task, optionally under an existing project.
+ * The in-conversation "file this as a task" path. Defaults to "backlog" status
+ * (excluded from auto-drain), so nothing auto-executes without promotion.
+ */
+export async function publicApiCreateWorkItem(
+  ctx: HandlerContext,
+  input: {
+    workspaceId: string;
+    projectId?: string;
+    title: string;
+    description?: string;
+    status?: string;
+  },
+) {
+  const workspace = await ctx.db.query.workspaces.findFirst({
+    where: eq(workspaces.id, input.workspaceId),
+  });
+  if (!workspace?.tenantId) {
+    throw new TRPCError({ code: "NOT_FOUND" });
+  }
+  await assertTenantAccess(ctx.db, ctx.userId, workspace.tenantId);
+
+  if (input.projectId) {
+    const proj = await ctx.db.query.projects.findFirst({
+      where: and(
+        eq(projects.id, input.projectId),
+        eq(projects.workspaceId, input.workspaceId),
+      ),
+      columns: { id: true },
+    });
+    if (!proj) {
+      throw new TRPCError({
+        code: "NOT_FOUND",
+        message: "project not found in workspace",
+      });
+    }
+  }
+
+  const [{ n } = { n: 0 }] = await ctx.db
+    .select({ n: sql<number>`count(*)` })
+    .from(workItems)
+    .where(eq(workItems.workspaceId, input.workspaceId));
+
+  const [wi] = await ctx.db
+    .insert(workItems)
+    .values({
+      ownerUserId: ctx.userId,
+      workspaceId: input.workspaceId,
+      projectId: input.projectId ?? null,
+      kind: "task",
+      title: input.title.slice(0, 256),
+      description: input.description ?? null,
+      status: input.status ?? "backlog",
+      sequenceNumber: Number(n) + 1,
+    })
+    .returning({
+      id: workItems.id,
+      title: workItems.title,
+      status: workItems.status,
+    });
+  if (!wi) {
+    throw new TRPCError({
+      code: "INTERNAL_SERVER_ERROR",
+      message: "Failed to create work item",
+    });
+  }
+  return { workItemId: wi.id, title: wi.title, status: wi.status };
+}
+
 export async function publicApiUpdateRun(
   ctx: HandlerContext,
   input: {

--- a/packages/bob/src/api/src/router/publicApi.ts
+++ b/packages/bob/src/api/src/router/publicApi.ts
@@ -12,6 +12,8 @@ import {
   publicApiCreateRun,
   publicApiDispatchExecution,
   publicApiCreateProject,
+  publicApiListProjects,
+  publicApiCreateWorkItem,
   publicApiUpdateRun,
   publicApiCreateArtifact,
   publicApiGetRun,
@@ -114,6 +116,34 @@ export const publicApiRouter = {
     )
     .mutation(({ ctx, input }) =>
       publicApiCreateProject(
+        { db: ctx.db, userId: ctx.session.user.id },
+        input,
+      ),
+    ),
+
+  // GET /projects — list a workspace's projects (for agents to file tasks).
+  listProjects: apiKeyReadProcedure
+    .input(z.object({ workspaceId: z.string().uuid() }))
+    .query(({ ctx, input }) =>
+      publicApiListProjects(
+        { db: ctx.db, userId: ctx.session.user.id },
+        input,
+      ),
+    ),
+
+  // POST /work-items — create a single task (optionally under a project).
+  createWorkItem: apiKeyWriteProcedure
+    .input(
+      z.object({
+        workspaceId: z.string().uuid(),
+        projectId: z.string().uuid().optional(),
+        title: z.string().min(1).max(256),
+        description: z.string().max(20000).optional(),
+        status: z.string().max(40).optional(),
+      }),
+    )
+    .mutation(({ ctx, input }) =>
+      publicApiCreateWorkItem(
         { db: ctx.db, userId: ctx.session.user.id },
         input,
       ),

--- a/packages/ooda/src/buddy-tools/handlers/bob.ts
+++ b/packages/ooda/src/buddy-tools/handlers/bob.ts
@@ -1,0 +1,110 @@
+// Bob / Kanbanger buddy tools. Unlike the research tools (which go through
+// ctx.trpc.research), these call Bob's public REST API directly from the runner
+// process, using the runner env: BOB_API_URL, BOB_API_KEY (a bob_* key), and
+// BOB_WORKSPACE_ID. This is the "turn the conversation into project work" path.
+import { ToolHandlerError } from "../handler.js";
+import type { ToolHandler } from "../handler.js";
+
+interface BobConfig {
+  apiUrl: string;
+  apiKey: string;
+  workspaceId: string;
+}
+
+function bobConfig(): BobConfig {
+  const apiUrl = process.env.BOB_API_URL?.replace(/\/+$/, "");
+  const apiKey = process.env.BOB_API_KEY;
+  const workspaceId = process.env.BOB_WORKSPACE_ID;
+  if (!apiUrl || !apiKey || !workspaceId) {
+    throw new ToolHandlerError(
+      "NOT_CONFIGURED",
+      "Bob is not configured (need BOB_API_URL, BOB_API_KEY, BOB_WORKSPACE_ID).",
+    );
+  }
+  return { apiUrl, apiKey, workspaceId };
+}
+
+async function bobFetch(
+  cfg: BobConfig,
+  path: string,
+  init: RequestInit,
+): Promise<Record<string, unknown>> {
+  const res = await fetch(`${cfg.apiUrl}${path}`, {
+    ...init,
+    headers: {
+      "Content-Type": "application/json",
+      Authorization: `Bearer ${cfg.apiKey}`,
+      ...(init.headers ?? {}),
+    },
+  });
+  if (!res.ok) {
+    const detail = await res.text().catch(() => "");
+    throw new ToolHandlerError(
+      res.status === 403 ? "FORBIDDEN" : "BOB_ERROR",
+      `Bob API ${res.status}: ${detail.slice(0, 300)}`,
+      { retryable: res.status >= 500 },
+    );
+  }
+  return (await res.json()) as Record<string, unknown>;
+}
+
+export const bob_list_projects: ToolHandler<"bob_list_projects"> = async () => {
+  const cfg = bobConfig();
+  const data = await bobFetch(
+    cfg,
+    `/api/v1/projects?workspaceId=${encodeURIComponent(cfg.workspaceId)}`,
+    { method: "GET" },
+  );
+  const projects = Array.isArray(data.projects) ? data.projects : [];
+  return {
+    projects: projects.map((p) => {
+      const proj = p as Record<string, unknown>;
+      return {
+        id: String(proj.id ?? ""),
+        key: String(proj.key ?? ""),
+        name: String(proj.name ?? ""),
+        status: proj.status == null ? null : String(proj.status),
+      };
+    }),
+  };
+};
+
+export const bob_create_task: ToolHandler<"bob_create_task"> = async (args) => {
+  const cfg = bobConfig();
+  const data = await bobFetch(cfg, `/api/v1/work-items/create`, {
+    method: "POST",
+    body: JSON.stringify({
+      workspaceId: cfg.workspaceId,
+      projectId: args.projectId,
+      title: args.title,
+      description: args.description,
+    }),
+  });
+  return {
+    workItemId: String(data.workItemId ?? ""),
+    title: String(data.title ?? args.title),
+    status: String(data.status ?? "backlog"),
+  };
+};
+
+export const bob_create_project: ToolHandler<"bob_create_project"> = async (
+  args,
+) => {
+  const cfg = bobConfig();
+  const data = await bobFetch(cfg, `/api/v1/projects`, {
+    method: "POST",
+    body: JSON.stringify({
+      workspaceId: cfg.workspaceId,
+      name: args.name,
+      description: args.description,
+      tasks: args.tasks,
+    }),
+  });
+  const workItems = Array.isArray(data.workItems) ? data.workItems : [];
+  return {
+    projectId: String(data.projectId ?? ""),
+    key: String(data.key ?? ""),
+    name: String(data.name ?? args.name),
+    taskCount: workItems.length,
+  };
+};

--- a/packages/ooda/src/buddy-tools/handlers/index.ts
+++ b/packages/ooda/src/buddy-tools/handlers/index.ts
@@ -14,6 +14,7 @@
 import type { ToolHandler } from "../handler";
 import type { ToolName } from "../schemas";
 
+import * as bob from "./bob";
 import * as cp from "./cp";
 import * as dive from "./dive";
 import * as graph from "./graph";
@@ -25,6 +26,9 @@ import * as papers from "./papers";
 import * as stubs from "./stubs";
 
 export const HANDLERS: Record<ToolName, ToolHandler<ToolName>> = {
+  bob_list_projects: bob.bob_list_projects as ToolHandler<ToolName>,
+  bob_create_task: bob.bob_create_task as ToolHandler<ToolName>,
+  bob_create_project: bob.bob_create_project as ToolHandler<ToolName>,
   dive_spawn: dive.dive_spawn as ToolHandler<ToolName>,
   dive_status: dive.dive_status as ToolHandler<ToolName>,
   dive_results: dive.dive_results as ToolHandler<ToolName>,
@@ -44,4 +48,4 @@ export const HANDLERS: Record<ToolName, ToolHandler<ToolName>> = {
   cp_open_url: cp.cp_open_url as ToolHandler<ToolName>,
 };
 
-export { cp, dive, graph, inbox, interests, kb, memory, papers, stubs };
+export { bob, cp, dive, graph, inbox, interests, kb, memory, papers, stubs };

--- a/packages/ooda/src/buddy-tools/schemas.ts
+++ b/packages/ooda/src/buddy-tools/schemas.ts
@@ -472,12 +472,70 @@ export const cp_open_url = {
 } as const;
 
 // ---------------------------------------------------------------------------
+// Bob / Kanbanger — turn a conversation into project work. Handlers call Bob's
+// public API directly (runner env: BOB_API_URL/BOB_API_KEY/BOB_WORKSPACE_ID).
+// ---------------------------------------------------------------------------
+
+export const bob_list_projects = {
+  name: "bob_list_projects",
+  description:
+    "List the user's Bob (Kanbanger) projects. Use this to find an existing project to file a task against before creating a new one.",
+  args: z.object({}),
+  result: z.object({
+    projects: z.array(
+      z.object({
+        id: z.string(),
+        key: z.string(),
+        name: z.string(),
+        status: z.string().nullable(),
+      }),
+    ),
+  }),
+} as const;
+
+export const bob_create_task = {
+  name: "bob_create_task",
+  description:
+    "Create a task in Bob (Kanbanger). Optionally file it under an existing project (projectId from bob_list_projects). New tasks land in the backlog. Use this to turn something from the conversation into a task.",
+  args: z.object({
+    title: z.string().min(1).max(256),
+    description: z.string().max(20000).optional(),
+    projectId: z.string().optional(),
+  }),
+  result: z.object({
+    workItemId: z.string(),
+    title: z.string(),
+    status: z.string(),
+  }),
+} as const;
+
+export const bob_create_project = {
+  name: "bob_create_project",
+  description:
+    "Create a new project in Bob (Kanbanger), optionally seeding an initial backlog of tasks. Use this to start a new project from the conversation.",
+  args: z.object({
+    name: z.string().min(1).max(128),
+    description: z.string().max(20000).optional(),
+    tasks: z.array(z.string().min(1).max(256)).max(20).optional(),
+  }),
+  result: z.object({
+    projectId: z.string(),
+    key: z.string(),
+    name: z.string(),
+    taskCount: z.number().int(),
+  }),
+} as const;
+
+// ---------------------------------------------------------------------------
 // Registry
 // ---------------------------------------------------------------------------
 
 // Tools with real backing (tRPC procedures exist; the handler resolves).
 // This is what agents should see in their tool surface today.
 export const TOOLS_IMPLEMENTED = {
+  bob_list_projects,
+  bob_create_task,
+  bob_create_project,
   dive_spawn,
   dive_status,
   dive_results,


### PR DESCRIPTION
The chat agent gets buddy tools to list projects, create tasks (in existing or new projects), and create projects — calling Bob's new public API. Turns brainstorms into real Kanbanger work.