### PR TITLE
feat(ooda): screenshot/vision capture→chat→agent

### DIFF
--- a/apps/ooda-edge/src/app/capture/page.tsx
+++ b/apps/ooda-edge/src/app/capture/page.tsx
@@ -33,7 +33,42 @@ export default function CapturePage() {
   const [debounced, setDebounced] = useState("");
   const [showImport, setShowImport] = useState(false);
   const [importJson, setImportJson] = useState("");
+  const [images, setImages] = useState<
+    { mimeType: string; dataBase64: string; preview: string }[]
+  >([]);
   const trpc = useTRPC();
+
+  // Paste a cropped screenshot straight into the capture box.
+  const addImageFile = (file: File) => {
+    if (!file.type.startsWith("image/")) return;
+    const reader = new FileReader();
+    reader.onload = () => {
+      const dataUrl = String(reader.result);
+      const comma = dataUrl.indexOf(",");
+      if (comma < 0) return;
+      setImages((prev) =>
+        prev.length >= 6
+          ? prev
+          : [
+              ...prev,
+              {
+                mimeType: file.type,
+                dataBase64: dataUrl.slice(comma + 1),
+                preview: dataUrl,
+              },
+            ],
+      );
+    };
+    reader.readAsDataURL(file);
+  };
+  const handlePaste = (e: React.ClipboardEvent) => {
+    for (const it of Array.from(e.clipboardData?.items ?? [])) {
+      if (it.kind === "file" && it.type.startsWith("image/")) {
+        const f = it.getAsFile();
+        if (f) addImageFile(f);
+      }
+    }
+  };
 
   // Debounce the capture text before searching the KB.
   useEffect(() => {
@@ -62,9 +97,25 @@ export default function CapturePage() {
           | { slug?: string }
           | undefined;
         if (t?.slug) {
-          window.location.assign(
-            `/threads/${t.slug}?prompt=${encodeURIComponent(text.trim())}`,
-          );
+          // Hand the capture (text + screenshots) to the new thread. Images are
+          // too big for a URL param, so ride sessionStorage; ChatPanel consumes
+          // it on mount and auto-sends.
+          try {
+            sessionStorage.setItem(
+              "ooda-capture-seed",
+              JSON.stringify({
+                prompt: text.trim(),
+                images: images.map((i) => ({
+                  mimeType: i.mimeType,
+                  dataBase64: i.dataBase64,
+                })),
+                ts: Date.now(),
+              }),
+            );
+          } catch {
+            // fall back to a text-only URL seed below
+          }
+          window.location.assign(`/threads/${t.slug}`);
         }
       },
     }),
@@ -100,6 +151,7 @@ export default function CapturePage() {
         <textarea
           value={text}
           onChange={(e) => setText(e.target.value)}
+          onPaste={handlePaste}
           onKeyDown={(e) => {
             if ((e.metaKey || e.ctrlKey) && e.key === "Enter") {
               e.preventDefault();
@@ -107,17 +159,40 @@ export default function CapturePage() {
             }
           }}
           autoFocus
-          placeholder="What's on your mind? Drop a thought, a question, a link…"
+          placeholder="What's on your mind? Paste a screenshot, drop a thought or a link…"
           className="w-full resize-none rounded-[8px] border border-[#2A2A2F] bg-[#1A1A1E] px-4 py-4 text-[15px] leading-relaxed text-[#E8E4DF] placeholder-[#5A5855] focus:border-[#D4A04A]/50 focus:outline-none"
           rows={5}
         />
+        {images.length > 0 && (
+          <div className="mt-3 flex flex-wrap gap-2">
+            {images.map((img, i) => (
+              <div key={i} className="relative">
+                {/* eslint-disable-next-line @next/next/no-img-element */}
+                <img
+                  src={img.preview}
+                  alt="screenshot"
+                  className="h-16 w-16 rounded-[4px] border border-[#2A2A2F] object-cover"
+                />
+                <button
+                  type="button"
+                  onClick={() =>
+                    setImages((prev) => prev.filter((_, j) => j !== i))
+                  }
+                  className="absolute -right-1.5 -top-1.5 flex h-4 w-4 items-center justify-center rounded-full bg-[#111113] text-[10px] text-[#8A8580] hover:text-[#E8E4DF]"
+                >
+                  ×
+                </button>
+              </div>
+            ))}
+          </div>
+        )}
         <div className="mt-3 flex items-center justify-between">
           <span className="text-xs text-[#5A5855]">
             {createThread.isPending
               ? "Opening conversation…"
               : createThread.isError
                 ? `Error: ${createThread.error.message}`
-                : "Screenshots + agent vision are coming next."}
+                : "Paste a screenshot — the agent can see it and can file tasks in your projects."}
           </span>
           <button
             onClick={startConversation}

--- a/apps/ooda-edge/src/components/threads/chat-panel.tsx
+++ b/apps/ooda-edge/src/components/threads/chat-panel.tsx
@@ -25,6 +25,42 @@ export function ChatPanel({ threadId, runnerId, onPromoted }: ChatPanelProps) {
   const [input, setInput] = useState("");
   const [messages, setMessages] = useState<ChatMessage[]>([]);
   const [activeSessionId, setActiveSessionId] = useState<string | null>(null);
+  const [attachedImages, setAttachedImages] = useState<
+    { mimeType: string; dataBase64: string; preview: string }[]
+  >([]);
+
+  // Paste/drop a screenshot into the chat → attach it (vision).
+  const addImageFile = (file: File) => {
+    if (!file.type.startsWith("image/")) return;
+    const reader = new FileReader();
+    reader.onload = () => {
+      const dataUrl = String(reader.result);
+      const comma = dataUrl.indexOf(",");
+      if (comma < 0) return;
+      setAttachedImages((prev) =>
+        prev.length >= 6
+          ? prev
+          : [
+              ...prev,
+              {
+                mimeType: file.type,
+                dataBase64: dataUrl.slice(comma + 1),
+                preview: dataUrl,
+              },
+            ],
+      );
+    };
+    reader.readAsDataURL(file);
+  };
+  const handlePaste = (e: React.ClipboardEvent) => {
+    const items = Array.from(e.clipboardData?.items ?? []);
+    for (const it of items) {
+      if (it.kind === "file" && it.type.startsWith("image/")) {
+        const f = it.getAsFile();
+        if (f) addImageFile(f);
+      }
+    }
+  };
   const messagesEndRef = useRef<HTMLDivElement>(null);
 
   const trpc = useTRPC();
@@ -96,17 +132,24 @@ export function ChatPanel({ threadId, runnerId, onPromoted }: ChatPanelProps) {
     }),
   );
 
-  const sendPromptText = (raw: string) => {
+  const sendPromptText = (
+    raw: string,
+    imgs?: { mimeType: string; dataBase64: string }[],
+  ) => {
     const prompt = raw.trim();
     if (!prompt || !availableRunner) return;
 
-    // Add user message immediately
+    // Add user message immediately (note any attached images).
     setMessages((prev) => [
       ...prev,
       {
         id: `user-${Date.now()}`,
         role: "user",
-        content: prompt,
+        content:
+          prompt +
+          (imgs && imgs.length
+            ? `\n\n📎 ${imgs.length} image${imgs.length > 1 ? "s" : ""} attached`
+            : ""),
         timestamp: new Date().toLocaleTimeString(),
       },
     ]);
@@ -114,19 +157,31 @@ export function ChatPanel({ threadId, runnerId, onPromoted }: ChatPanelProps) {
     sendMutation.mutate({
       threadId,
       runnerId: availableRunner,
-      adapterId: chooseDefaultAdapter(
-        runners.find((runner) => runner.id === availableRunner),
-      ),
+      // Images need the vision-capable adapter (claude); text uses the default.
+      adapterId:
+        imgs && imgs.length
+          ? "claude"
+          : chooseDefaultAdapter(
+              runners.find((runner) => runner.id === availableRunner),
+            ),
       toolProfileId: "default",
       prompt,
+      ...(imgs && imgs.length ? { images: imgs } : {}),
     });
   };
 
   const handleSubmit = (e: React.FormEvent) => {
     e.preventDefault();
     if (!input.trim() || !availableRunner) return;
-    sendPromptText(input);
+    sendPromptText(
+      input,
+      attachedImages.map((i) => ({
+        mimeType: i.mimeType,
+        dataBase64: i.dataBase64,
+      })),
+    );
     setInput("");
+    setAttachedImages([]);
   };
 
   // Capture-first seeding: a thread opened from Capture carries the captured
@@ -135,8 +190,32 @@ export function ChatPanel({ threadId, runnerId, onPromoted }: ChatPanelProps) {
   // waits in the input box instead.
   const seededRef = useRef(false);
   const [pendingSeed, setPendingSeed] = useState<string | null>(null);
+  const [pendingImages, setPendingImages] = useState<
+    { mimeType: string; dataBase64: string }[] | null
+  >(null);
   useEffect(() => {
     if (typeof window === "undefined") return;
+    // Rich capture seed (text + screenshots) handed off via sessionStorage —
+    // used when Capture passed images (too big for a URL param).
+    try {
+      const raw = sessionStorage.getItem("ooda-capture-seed");
+      if (raw) {
+        sessionStorage.removeItem("ooda-capture-seed");
+        const seed = JSON.parse(raw) as {
+          prompt?: string;
+          images?: { mimeType: string; dataBase64: string }[];
+          ts?: number;
+        };
+        if (seed.prompt && Date.now() - (seed.ts ?? 0) < 120_000) {
+          setPendingSeed(seed.prompt);
+          if (seed.images?.length) setPendingImages(seed.images);
+          setInput(seed.prompt);
+          return;
+        }
+      }
+    } catch {
+      // ignore malformed seed
+    }
     const p = new URLSearchParams(window.location.search).get("prompt");
     if (!p) return;
     setPendingSeed(p);
@@ -148,9 +227,10 @@ export function ChatPanel({ threadId, runnerId, onPromoted }: ChatPanelProps) {
   useEffect(() => {
     if (seededRef.current || !pendingSeed || !availableRunner) return;
     seededRef.current = true;
-    sendPromptText(pendingSeed);
+    sendPromptText(pendingSeed, pendingImages ?? undefined);
     setInput("");
     setPendingSeed(null);
+    setPendingImages(null);
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [pendingSeed, availableRunner]);
 
@@ -272,12 +352,42 @@ export function ChatPanel({ threadId, runnerId, onPromoted }: ChatPanelProps) {
             </button>
           </div>
         )}
+        {attachedImages.length > 0 && (
+          <div className="mb-2 flex flex-wrap gap-2">
+            {attachedImages.map((img, i) => (
+              <div key={i} className="relative">
+                {/* eslint-disable-next-line @next/next/no-img-element */}
+                <img
+                  src={img.preview}
+                  alt="attachment"
+                  className="h-14 w-14 rounded-[3px] border border-[#2A2A2F] object-cover"
+                />
+                <button
+                  type="button"
+                  onClick={() =>
+                    setAttachedImages((prev) =>
+                      prev.filter((_, j) => j !== i),
+                    )
+                  }
+                  className="absolute -right-1.5 -top-1.5 flex h-4 w-4 items-center justify-center rounded-full bg-[#111113] text-[10px] text-[#8A8580] hover:text-[#E8E4DF]"
+                >
+                  ×
+                </button>
+              </div>
+            ))}
+          </div>
+        )}
         <div className="flex gap-2">
           <input
             type="text"
             value={input}
             onChange={(e) => setInput(e.target.value)}
-            placeholder={isRunning ? "Agent is working..." : "Ask a research question..."}
+            onPaste={handlePaste}
+            placeholder={
+              isRunning
+                ? "Agent is working..."
+                : "Ask a research question… (paste a screenshot)"
+            }
             disabled={isRunning}
             className="flex-1 rounded-[3px] border border-[#2A2A2F] bg-[#1A1A1E] px-3 py-2.5 text-sm text-[#E8E4DF] placeholder-[#5A5855] outline-none focus:border-[#D4A04A] disabled:opacity-50"
           />

--- a/apps/ooda-runner/src/runner-server.ts
+++ b/apps/ooda-runner/src/runner-server.ts
@@ -10,7 +10,7 @@ import { CodexAdapter } from "@gmacko/ooda/agent-adapters";
 import { ClaudeAdapter } from "@gmacko/ooda/agent-adapters";
 import { GrokAdapter } from "@gmacko/ooda/agent-adapters";
 import { BuddyMcpServer } from "@gmacko/ooda/agent-adapters";
-import type { AgentAdapter } from "@gmacko/ooda/agent-adapters";
+import type { AgentAdapter, PromptImage } from "@gmacko/ooda/agent-adapters";
 import { generateRunnerToken } from "./auth/auth";
 import { promoteNote } from "@gmacko/ooda/thread-workspace";
 import { resolveThreadPath } from "@gmacko/ooda/thread-model";
@@ -462,6 +462,20 @@ export class RunnerServer {
         throw new Error("No prompt found for session");
       }
 
+      // Images attached to the prompt (vision), stored as a sibling event.
+      const imagesEvent = events.find(
+        (e: { type: string }) => e.type === "prompt_images",
+      ) as { content?: string } | undefined;
+      let promptImages: PromptImage[] | undefined;
+      if (imagesEvent?.content) {
+        try {
+          const parsed = JSON.parse(imagesEvent.content);
+          if (Array.isArray(parsed) && parsed.length > 0) promptImages = parsed;
+        } catch {
+          // malformed images blob — proceed text-only
+        }
+      }
+
       // Get thread info for workspace creation
       const thread = await this.trpc.threads.byId.query({
         id: session.threadId,
@@ -493,6 +507,7 @@ export class RunnerServer {
         sessionId: session.id,
         threadId: session.threadId,
         prompt: promptEvent.content,
+        images: promptImages,
         toolProfileId: session.toolProfileId,
         onEvent: (event) => {
           if (event.type === "stdout") {

--- a/apps/ooda-runner/src/session/session-executor.ts
+++ b/apps/ooda-runner/src/session/session-executor.ts
@@ -1,6 +1,6 @@
 import { existsSync } from "node:fs";
 
-import type { AgentAdapter, AdapterEvent, BuddyMcpServer } from "@gmacko/ooda/agent-adapters";
+import type { AgentAdapter, AdapterEvent, BuddyMcpServer, PromptImage } from "@gmacko/ooda/agent-adapters";
 import {
   createBuddyToolDescriptors,
   registerTools,
@@ -60,6 +60,8 @@ export interface ExecuteSessionInput {
   threadTitle: string;
   sessionId: string;
   prompt: string;
+  /** Images attached to the prompt (vision); passed to the first message. */
+  images?: PromptImage[];
   toolProfileId: string;
   /**
    * Thread id the buddy-tool handlers thread through their tRPC calls.
@@ -120,6 +122,7 @@ export class SessionExecutor {
         prompt: input.prompt,
         workspaceRoot: threadDir,
         systemPrompt: input.systemPrompt,
+        images: input.images,
       });
 
       // Capture output

--- a/packages/ooda/src/agent-adapters/claude-adapter.ts
+++ b/packages/ooda/src/agent-adapters/claude-adapter.ts
@@ -13,6 +13,7 @@ import type {
   BuildCommandOptions,
   ExecuteOptions,
   McpServerConfigLike,
+  PromptImage,
   SpawnedProcessLike,
 } from "./types";
 
@@ -126,6 +127,7 @@ export class ClaudeAdapter implements AgentAdapter {
       args,
       cwd: opts.workspaceRoot,
       prompt: opts.prompt,
+      images: opts.images,
     };
   }
 
@@ -232,7 +234,10 @@ export class ClaudeAdapter implements AgentAdapter {
       return true;
     };
 
-    const writeUserMessage = (text: string): boolean => {
+    const writeUserMessage = (
+      text: string,
+      images?: PromptImage[],
+    ): boolean => {
       if (!stdinOpen || !child.stdin || child.stdin.destroyed) return false;
       // A new message cancels any pending close — it either joins the current
       // turn or starts the next one; the next `result` re-arms the timer.
@@ -240,10 +245,27 @@ export class ClaudeAdapter implements AgentAdapter {
         clearTimeout(idleCloseTimer);
         idleCloseTimer = null;
       }
+      // Attach images as stream-json content blocks on the first message.
+      // Verified: the claude CLI reads image blocks over --input-format
+      // stream-json stdin and the model sees them.
+      const content =
+        images && images.length > 0
+          ? [
+              { type: "text", text },
+              ...images.map((img) => ({
+                type: "image",
+                source: {
+                  type: "base64",
+                  media_type: img.mimeType,
+                  data: img.dataBase64,
+                },
+              })),
+            ]
+          : text;
       child.stdin.write(
         JSON.stringify({
           type: "user",
-          message: { role: "user", content: text },
+          message: { role: "user", content },
         }) + "\n",
       );
       return true;
@@ -266,7 +288,7 @@ export class ClaudeAdapter implements AgentAdapter {
     };
 
     if (interactive && command.prompt) {
-      writeUserMessage(command.prompt);
+      writeUserMessage(command.prompt, command.images);
     }
     options?.onSpawn?.(handle);
 

--- a/packages/ooda/src/agent-adapters/index.ts
+++ b/packages/ooda/src/agent-adapters/index.ts
@@ -7,6 +7,7 @@ export {
   type AgentAdapter,
   type ExecuteOptions,
   type McpServerConfigLike,
+  type PromptImage,
   type SpawnedProcessLike,
   type ToolDescriptorLike,
 } from "./types";

--- a/packages/ooda/src/agent-adapters/types.ts
+++ b/packages/ooda/src/agent-adapters/types.ts
@@ -22,12 +22,24 @@ export interface AdapterCommand {
    * CLI-spawn adapters bake the prompt into `args` and leave this unset.
    */
   prompt?: string;
+  /** Images to attach to the first user message (vision). Claude adapter only. */
+  images?: PromptImage[];
+}
+
+/** An image attached to a prompt (base64), passed to the model as vision. */
+export interface PromptImage {
+  /** MIME type, e.g. "image/png" or "image/jpeg". */
+  mimeType: string;
+  /** Base64-encoded image bytes (no data: prefix). */
+  dataBase64: string;
 }
 
 export interface BuildCommandOptions {
   prompt: string;
   workspaceRoot: string;
   systemPrompt?: string;
+  /** Images to attach to the first user message (vision). */
+  images?: PromptImage[];
   /** Persona-selected model (e.g. a specific Claude model id). */
   model?: string;
   /** Persona-restricted tool allowlist passed to the agent CLI. */

--- a/packages/ooda/src/api/router/runner.ts
+++ b/packages/ooda/src/api/router/runner.ts
@@ -115,6 +115,16 @@ export const runnerRouter = {
         adapterId: z.string(),
         toolProfileId: z.string(),
         prompt: z.string().min(1),
+        // Images attached to the prompt (vision). Base64 (no data: prefix).
+        images: z
+          .array(
+            z.object({
+              mimeType: z.string().max(64),
+              dataBase64: z.string(),
+            }),
+          )
+          .max(6)
+          .optional(),
       }),
     )
     .output(z.any())
@@ -131,13 +141,21 @@ export const runnerRouter = {
         })
         .returning();
 
-      // Store the prompt as the first event
+      // Store the prompt as the first event; images as a sibling event so the
+      // runner can attach them to the first message (see executeSession).
       if (session) {
         await ctx.db.insert(sessionEvent).values({
           sessionId: session.id,
           type: "prompt",
           content: input.prompt,
         });
+        if (input.images && input.images.length > 0) {
+          await ctx.db.insert(sessionEvent).values({
+            sessionId: session.id,
+            type: "prompt_images",
+            content: JSON.stringify(input.images),
+          });
+        }
       }
 
       return session;


### PR DESCRIPTION
Spike-verified claude CLI accepts image content blocks; wired images end-to-end (sendPrompt→storage→executor→adapter stream-json image blocks) + paste-to-attach in ChatPanel + Capture screenshot handoff.